### PR TITLE
Fixing zip action creation

### DIFF
--- a/parsers/manifest_parser.go
+++ b/parsers/manifest_parser.go
@@ -25,7 +25,7 @@ import (
 	"path"
 	"strings"
 
-    "encoding/base64"
+    	"encoding/base64"
 	"encoding/json"
 
 	"github.com/apache/incubator-openwhisk-client-go/whisk"

--- a/parsers/manifest_parser.go
+++ b/parsers/manifest_parser.go
@@ -262,9 +262,9 @@ func (dm *YAMLParser) ComposeActions(mani *ManifestYAML, manipath string) (ar []
 				dat, err := utils.Read(filePath)
 				utils.Check(err)
 				code := string(dat)
-                if ext == ".zip" || ext == ".jar" {
-                    code = base64.StdEncoding.EncodeToString([]byte(dat))
-                }
+                		if ext == ".zip" || ext == ".jar" {
+                    			code = base64.StdEncoding.EncodeToString([]byte(dat))
+                		}
 				wskaction.Exec.Code = &code
 			}
 

--- a/parsers/manifest_parser.go
+++ b/parsers/manifest_parser.go
@@ -25,6 +25,7 @@ import (
 	"path"
 	"strings"
 
+    "encoding/base64"
 	"encoding/json"
 
 	"github.com/apache/incubator-openwhisk-client-go/whisk"
@@ -243,12 +244,6 @@ func (dm *YAMLParser) ComposeActions(mani *ManifestYAML, manipath string) (ar []
 				// To do: support docker and main entry as did by go cli?
 				wskaction.Exec, err = utils.GetExec(zipName, action.Runtime, false, "")
 			} else {
-				action.Location = filePath
-				dat, err := utils.Read(filePath)
-				utils.Check(err)
-				code := string(dat)
-				wskaction.Exec.Code = &code
-
 				ext := path.Ext(filePath)
 				kind := "nodejs:default"
 
@@ -262,6 +257,15 @@ func (dm *YAMLParser) ComposeActions(mani *ManifestYAML, manipath string) (ar []
 				}
 
 				wskaction.Exec.Kind = kind
+
+				action.Location = filePath
+				dat, err := utils.Read(filePath)
+				utils.Check(err)
+				code := string(dat)
+                if ext == ".zip" || ext == ".jar" {
+                    code = base64.StdEncoding.EncodeToString([]byte(dat))
+                }
+				wskaction.Exec.Code = &code
 			}
 
 		}

--- a/tests/src/integration/manifest.yaml
+++ b/tests/src/integration/manifest.yaml
@@ -1,0 +1,6 @@
+package:
+    name: helloworld
+    actions:
+        helloworld:
+            location: src/helloworld.zip
+            kind: nodejs:6

--- a/tests/src/integration/zipaction/src/index.js
+++ b/tests/src/integration/zipaction/src/index.js
@@ -1,0 +1,5 @@
+function helloworld(params) {
+    return { payload: 'Hello World!' };
+}
+
+exports.main = helloworld;

--- a/tests/src/integration/zipaction/zipaction_test.go
+++ b/tests/src/integration/zipaction/zipaction_test.go
@@ -23,6 +23,6 @@ func TestZipAction(t *testing.T) {
 }
 
 var (
-	manifestPath   = os.Getenv("GOPATH") + "/src/github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/zipaction/manifest.yml"
+	manifestPath   = os.Getenv("GOPATH") + "/src/github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/zipaction/manifest.yaml"
 	deploymentPath = "" 
 )

--- a/tests/src/integration/zipaction/zipaction_test.go
+++ b/tests/src/integration/zipaction/zipaction_test.go
@@ -1,0 +1,28 @@
+// +build integration
+
+package tests
+
+import (
+	"github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/common"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+
+var wskprops = common.GetWskprops()
+
+// TODO: write the integration against openwhisk
+func TestZipAction(t *testing.T) {
+	os.Setenv("__OW_API_HOST", wskprops.APIHost)
+	wskdeploy := common.NewWskdeploy()
+	_, err := wskdeploy.Deploy(manifestPath, deploymentPath)
+	assert.Equal(t, nil, err, "Failed to deploy based on the manifest and deployment files.")
+	_, err = wskdeploy.Undeploy(manifestPath, deploymentPath)
+	assert.Equal(t, nil, err, "Failed to undeploy based on the manifest and deployment files.")
+}
+
+var (
+	manifestPath   = os.Getenv("GOPATH") + "/src/github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/zipaction/manifest.yml"
+	deploymentPath = "" 
+)

--- a/tests/src/integration/zipaction/zipaction_test.go
+++ b/tests/src/integration/zipaction/zipaction_test.go
@@ -12,7 +12,6 @@ import (
 
 var wskprops = common.GetWskprops()
 
-// TODO: write the integration against openwhisk
 func TestZipAction(t *testing.T) {
 	os.Setenv("__OW_API_HOST", wskprops.APIHost)
 	wskdeploy := common.NewWskdeploy()


### PR DESCRIPTION
Base64 encoding zipfile content so that action payload is sent in expected format via HTTP request.

Also, added integration test for a simple zip action.

Fixes #273