### PR TITLE
Update the client go version to f26793c94fd6883867eaa98ed8249024128cbcc6

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -105,11 +105,11 @@
 		},
 		{
 			"ImportPath": "github.com/apache/incubator-openwhisk-client-go/whisk",
-			"Rev": "62ddca28397566aaa46ac06484d79bd6da74011f"
+			"Rev": "f26793c94fd6883867eaa98ed8249024128cbcc6"
 		},
 		{
 			"ImportPath": "github.com/apache/incubator-openwhisk-client-go/wski18n",
-			"Rev": "62ddca28397566aaa46ac06484d79bd6da74011f"
+			"Rev": "f26793c94fd6883867eaa98ed8249024128cbcc6"
 		},
 		{
 			"ImportPath": "github.com/pelletier/go-buffruneio",


### PR DESCRIPTION
This PR pins the version of the client go to the f26793c94fd6883867eaa98ed8249024128cbcc6.