### PR TITLE
Update openwhisk install to use incubator repo.

### DIFF
--- a/tools/travis/install_openwhisk.sh
+++ b/tools/travis/install_openwhisk.sh
@@ -3,8 +3,8 @@
 HOMEDIR="$(dirname "$TRAVIS_BUILD_DIR")"
 cd $HOMEDIR
 
-# OpenWhisk stuff
-git clone --depth 3 https://github.com/openwhisk/openwhisk.git
+# OpenWhisk clone to fixed directory location
+git clone --depth 3 https://github.com/apache/incubator-openwhisk.git openwhisk
 
 # Build script for Travis-CI.
 WHISKDIR="$HOMEDIR/openwhisk"


### PR DESCRIPTION
Fixes location and puts files into an "openwhisk" directory to permit rest of script to remain unchanged.  Addresses comments on PR https://github.com/apache/incubator-openwhisk-wskdeploy/pull/285/files which can be closed if this is merged.