### PR TITLE
indentation error in deployment.yaml and invalid comment in manifest file

### DIFF
--- a/tests/usecases/triggerrule/deployment.yml
+++ b/tests/usecases/triggerrule/deployment.yml
@@ -7,7 +7,7 @@ application:
   package:
     triggerrule:
       name: helloworld
-     namespace: guest
+      namespace: guest
       actions:
         greeting:
           inputs:

--- a/tests/usecases/triggerrule/manifest.yml
+++ b/tests/usecases/triggerrule/manifest.yml
@@ -17,7 +17,5 @@ package:
   rules:
     myRule:
       trigger: locationUpdate
-      #the action name and the action file greeting.js should consistent.
-      #currently the implementation deside the action name consistent with action file name?
       action: greeting
 


### PR DESCRIPTION
"namespace" indentation incorrect; results in parser error:

```
  package:
    triggerrule:
      name: helloworld
     namespace: guest
      actions:
        greeting:
          inputs:
            name: Bernie
            place: DC
```