### PR TITLE
add three additional parms to test defaulting type values.

### DIFF
--- a/tests/dat/manifest_validate_singleline_params.yaml
+++ b/tests/dat/manifest_validate_singleline_params.yaml
@@ -24,6 +24,10 @@ package:
                 param_simple_implied_empty:
                 param_simple_explicit_empty_1: ''
                 param_simple_explicit_empty_2: ""
+                # Type names (should default to a value for that type)
+                param_simple_type_string: string
+                param_simple_type_integer: integer
+                param_simple_type_float: float
             outputs:
                 payload:
                     type: string


### PR DESCRIPTION
# Type names (should default to a value for that type)
param_simple_type_string: string
param_simple_type_integer: integer
param_simple_type_float: float

The code should detect these are type names (not values) and replace them with the type's default.