### PR TITLE
Restore the integration tests

### DIFF
--- a/deployers/servicedeployer.go
+++ b/deployers/servicedeployer.go
@@ -537,19 +537,19 @@ func (deployer *ServiceDeployer) UnDeploy(verifiedPlan *DeploymentApplication) e
 
 func (deployer *ServiceDeployer) unDeployAssets(verifiedPlan *DeploymentApplication) error {
 
+    if err := deployer.UnDeployRules(verifiedPlan); err != nil {
+        return err
+    }
+
+    if err := deployer.UnDeploySequences(verifiedPlan); err != nil {
+        return err
+    }
+
 	if err := deployer.UnDeployActions(verifiedPlan); err != nil {
 		return err
 	}
 
-	if err := deployer.UnDeploySequences(verifiedPlan); err != nil {
-		return err
-	}
-
 	if err := deployer.UnDeployTriggers(verifiedPlan); err != nil {
-		return err
-	}
-
-	if err := deployer.UnDeployRules(verifiedPlan); err != nil {
 		return err
 	}
 

--- a/deployers/whiskclient.go
+++ b/deployers/whiskclient.go
@@ -177,6 +177,7 @@ func NewWhiskClient(proppath string, deploymentPath string, manifestPath string,
     clientConfig = &whisk.Config{
         AuthToken: credential.Value, //Authtoken
         Namespace: namespace.Value,  //Namespace
+        Host: apiHost.Value,
         BaseURL:   baseURL,
         Version:   "v1",
         Insecure:  true, // true if you want to ignore certificate signing

--- a/tests/src/integration/common/wskdeploy.go
+++ b/tests/src/integration/common/wskdeploy.go
@@ -86,6 +86,14 @@ func (wskdeploy *Wskdeploy) DeployProjectPathOnly(projectPath string) ([]byte, e
         return wskdeploy.RunCommand("-p", projectPath)
 }
 
+func (wskdeploy *Wskdeploy) UndeployProjectPathOnly(projectPath string) ([]byte, error) {
+    return wskdeploy.RunCommand("undeploy", "-p", projectPath)
+}
+
 func (wskdeploy *Wskdeploy) DeployManifestPathOnly(manifestpath string) ([]byte, error) {
-	return wskdeploy.RunCommand("-p", manifestpath)
+	return wskdeploy.RunCommand("-m", manifestpath)
+}
+
+func (wskdeploy *Wskdeploy) UndeployManifestPathOnly(manifestpath string) ([]byte, error) {
+    return wskdeploy.RunCommand("undeploy", "-m", manifestpath)
 }

--- a/tests/src/integration/dependency/dependencyTest.go
+++ b/tests/src/integration/dependency/dependencyTest.go
@@ -1,5 +1,3 @@
-// +build not_integration
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -29,8 +27,8 @@ import (
 
 var wskprops = common.GetWskprops()
 
-
-func TestZipAction(t *testing.T) {
+// TODO: write the integration against openwhisk
+func RunTestDependency(t *testing.T) {
     wskdeploy := common.NewWskdeploy()
     _, err := wskdeploy.Deploy(manifestPath, deploymentPath)
     assert.Equal(t, nil, err, "Failed to deploy based on the manifest and deployment files.")
@@ -39,6 +37,6 @@ func TestZipAction(t *testing.T) {
 }
 
 var (
-    manifestPath   = os.Getenv("GOPATH") + "/src/github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/zipaction/manifest.yml"
-    deploymentPath = os.Getenv("GOPATH") + "/src/github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/zipaction/deployment.yml"
+    manifestPath   = os.Getenv("GOPATH") + "/src/github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/dependency/manifest.yaml"
+    deploymentPath = ""
 )

--- a/tests/src/integration/dependency/manifest.yaml
+++ b/tests/src/integration/dependency/manifest.yaml
@@ -1,8 +1,5 @@
 package:
   name: opentest
-  namespace: guest
-  credential: 23bc46b1-71f6-4ed5-8c54-816aa4f8c502:123zO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP
-  apiHost: 172.17.0.1
   dependencies:
     hellowhisk:
       location: github.com/paulcastro/hellowhisk

--- a/tests/src/integration/flagstests/flagsTest.go
+++ b/tests/src/integration/flagstests/flagsTest.go
@@ -1,5 +1,3 @@
-// +build not_integration
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -17,7 +15,7 @@
  * limitations under the License.
  */
 
-package tests
+package flagstests
 
 import (
 	"github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/common"
@@ -29,51 +27,63 @@ import (
 var wskprops = common.GetWskprops()
 
 // support only projectpath flag
-func TestSupportProjectPath(t *testing.T) {
+func RunTestSupportProjectPath(t *testing.T) {
 	wskdeploy := common.NewWskdeploy()
 	projectPath := os.Getenv("GOPATH") + "/src/github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/flagstests"
 	_, err := wskdeploy.DeployProjectPathOnly(projectPath)
 	assert.Equal(t, nil, err, "Failed to deploy based on the projectpath")
+    _, err = wskdeploy.UndeployProjectPathOnly(projectPath)
+    assert.Equal(t, nil, err, "Failed to undeploy based on the projectpath")
 }
 
 // support only projectpath with trailing slash
-func TestSupportProjectPathTrailingSlash(t *testing.T) {
+func RunTestSupportProjectPathTrailingSlash(t *testing.T) {
 	wskdeploy := common.NewWskdeploy()
 	projectPath := os.Getenv("GOPATH") + "/src/github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/flagstests" + "/"
 	_, err := wskdeploy.DeployProjectPathOnly(projectPath)
 	assert.Equal(t, nil, err, "Failed to deploy based on the projectpath")
+    _, err = wskdeploy.UndeployProjectPathOnly(projectPath)
+    assert.Equal(t, nil, err, "Failed to undeploy based on the projectpath")
 }
 
 // only a yaml manifest
-func TestSupportManifestYamlPath(t *testing.T) {
+func RunTestSupportManifestYamlPath(t *testing.T) {
 	wskdeploy := common.NewWskdeploy()
 	manifestPath := os.Getenv("GOPATH") + "/src/github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/flagstests/manifest.yaml"
 	_, err := wskdeploy.DeployManifestPathOnly(manifestPath)
 	assert.Equal(t, nil, err, "Failed to deploy based on the manifestpath")
+    _, err = wskdeploy.UndeployManifestPathOnly(manifestPath)
+    assert.Equal(t, nil, err, "Failed to undeploy based on the projectpath")
 }
 
 // only a yml manifest
-func TestSupportManifestYmlPath(t *testing.T) {
+func RunTestSupportManifestYmlPath(t *testing.T) {
 	wskdeploy := common.NewWskdeploy()
 	manifestPath := os.Getenv("GOPATH") + "/src/github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/flagstests/manifest.yml"
 	_, err := wskdeploy.DeployManifestPathOnly(manifestPath)
 	assert.Equal(t, nil, err, "Failed to deploy based on the manifestpath")
+    _, err = wskdeploy.UndeployManifestPathOnly(manifestPath)
+    assert.Equal(t, nil, err, "Failed to undeploy based on the projectpath")
 }
 
 // manifest yaml and deployment yaml
-func TestSupportManifestYamlDeployment(t *testing.T) {
+func RunTestSupportManifestYamlDeployment(t *testing.T) {
 	wskdeploy := common.NewWskdeploy()
 	manifestPath := os.Getenv("GOPATH") + "/src/github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/flagstests/manifest.yaml"
 	deploymentPath := os.Getenv("GOPATH") + "/src/github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/flagstests/deployment.yml"
 	_, err := wskdeploy.Deploy(manifestPath,deploymentPath)
 	assert.Equal(t, nil, err, "Failed to deploy based on the manifestpath and deploymentpath.")
+    _, err = wskdeploy.Undeploy(manifestPath, deploymentPath)
+    assert.Equal(t, nil, err, "Failed to undeploy based on the manifest and deployment files.")
 }
 
 // manifest yml and deployment yaml
-func TestSupportManifestYmlDeployment(t *testing.T) {
+func RunTestSupportManifestYmlDeployment(t *testing.T) {
 	wskdeploy := common.NewWskdeploy()
 	manifestPath := os.Getenv("GOPATH") + "/src/github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/flagstests/manifest.yml"
 	deploymentPath := os.Getenv("GOPATH") + "/src/github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/flagstests/deployment.yml"
 	_, err := wskdeploy.Deploy(manifestPath,deploymentPath)
 	assert.Equal(t, nil, err, "Failed to deploy based on the manifestpath and deploymentpath.")
+    _, err = wskdeploy.Undeploy(manifestPath, deploymentPath)
+    assert.Equal(t, nil, err, "Failed to undeploy based on the manifest and deployment files.")
 }

--- a/tests/src/integration/integration_test.go
+++ b/tests/src/integration/integration_test.go
@@ -1,0 +1,49 @@
+// +build integration
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration
+
+import (
+    "testing"
+    "github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/triggerrule"
+    "github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/zipaction"
+    "github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/jaraction"
+    "github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/flagstests"
+)
+
+func TestJarAction(t *testing.T) {
+    jaraction.RunTestJarAction(t)
+}
+
+func TestTriggerRule(t *testing.T) {
+    triggerrule.RunTestTriggerRule(t)
+}
+
+func TestZipAction(t *testing.T) {
+    zipaction.RunTestZipAction(t)
+}
+
+func TestFlags(t *testing.T) {
+    flagstests.RunTestSupportProjectPath(t)
+    flagstests.RunTestSupportProjectPathTrailingSlash(t)
+    flagstests.RunTestSupportManifestYamlPath(t)
+    flagstests.RunTestSupportManifestYmlPath(t)
+    flagstests.RunTestSupportManifestYamlDeployment(t)
+    flagstests.RunTestSupportManifestYmlDeployment(t)
+}

--- a/tests/src/integration/jaraction/jaractionTest.go
+++ b/tests/src/integration/jaraction/jaractionTest.go
@@ -1,5 +1,3 @@
-// +build integration
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -17,19 +15,19 @@
  * limitations under the License.
  */
 
-package tests
+package jaraction
 
 import (
-	"testing"
 	"github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/common"
 	"github.com/stretchr/testify/assert"
 	"os"
+	"testing"
 )
+
 
 var wskprops = common.GetWskprops()
 
-// TODO: write the integration against openwhisk
-func TestTriggerRule(t *testing.T) {
+func RunTestJarAction(t *testing.T) {
 	wskdeploy := common.NewWskdeploy()
 	_, err := wskdeploy.Deploy(manifestPath, deploymentPath)
 	assert.Equal(t, nil, err, "Failed to deploy based on the manifest and deployment files.")
@@ -38,7 +36,6 @@ func TestTriggerRule(t *testing.T) {
 }
 
 var (
-	manifestPath = os.Getenv("GOPATH") + "/src/github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/triggerrule/manifest.yml"
-	deploymentPath = os.Getenv("GOPATH") + "/src/github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/triggerrule/deployment.yml"
+	manifestPath   = os.Getenv("GOPATH") + "/src/github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/jaraction/manifest.yaml"
+	deploymentPath = ""
 )
-

--- a/tests/src/integration/triggerrule/triggerruleTest.go
+++ b/tests/src/integration/triggerrule/triggerruleTest.go
@@ -1,5 +1,3 @@
-// +build not_integration
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -17,20 +15,16 @@
  * limitations under the License.
  */
 
-package tests
+package triggerrule
 
 import (
+	"testing"
 	"github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/common"
 	"github.com/stretchr/testify/assert"
 	"os"
-	"testing"
 )
 
-
-var wskprops = common.GetWskprops()
-
-// TODO: write the integration against openwhisk
-func TestWebAction(t *testing.T) {
+func RunTestTriggerRule(t *testing.T) {
 	wskdeploy := common.NewWskdeploy()
 	_, err := wskdeploy.Deploy(manifestPath, deploymentPath)
 	assert.Equal(t, nil, err, "Failed to deploy based on the manifest and deployment files.")
@@ -39,6 +33,7 @@ func TestWebAction(t *testing.T) {
 }
 
 var (
-	manifestPath   = os.Getenv("GOPATH") + "/src/github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/webaction/manifest.yml"
-	deploymentPath = os.Getenv("GOPATH") + "/src/github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/webaction/deployment.yml"
+	manifestPath = os.Getenv("GOPATH") + "/src/github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/triggerrule/manifest.yml"
+	deploymentPath = os.Getenv("GOPATH") + "/src/github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/triggerrule/deployment.yml"
 )
+

--- a/tests/src/integration/webaction/webactionTest.go
+++ b/tests/src/integration/webaction/webactionTest.go
@@ -1,5 +1,3 @@
-// +build not_integration
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -29,7 +27,8 @@ import (
 
 var wskprops = common.GetWskprops()
 
-func TestJarAction(t *testing.T) {
+// TODO: write the integration against openwhisk
+func RunTestWebAction(t *testing.T) {
 	wskdeploy := common.NewWskdeploy()
 	_, err := wskdeploy.Deploy(manifestPath, deploymentPath)
 	assert.Equal(t, nil, err, "Failed to deploy based on the manifest and deployment files.")
@@ -38,6 +37,6 @@ func TestJarAction(t *testing.T) {
 }
 
 var (
-	manifestPath   = os.Getenv("GOPATH") + "/src/github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/jaraction/manifest.yaml"
-	deploymentPath = ""
+	manifestPath   = os.Getenv("GOPATH") + "/src/github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/webaction/manifest.yml"
+	deploymentPath = os.Getenv("GOPATH") + "/src/github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/webaction/deployment.yml"
 )

--- a/tests/src/integration/zipaction/zipactionTest.go
+++ b/tests/src/integration/zipaction/zipactionTest.go
@@ -1,5 +1,3 @@
-// +build not_integration
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -17,7 +15,7 @@
  * limitations under the License.
  */
 
-package tests
+package zipaction
 
 import (
     "github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/common"
@@ -29,8 +27,8 @@ import (
 
 var wskprops = common.GetWskprops()
 
-// TODO: write the integration against openwhisk
-func TestDependency(t *testing.T) {
+
+func RunTestZipAction(t *testing.T) {
     wskdeploy := common.NewWskdeploy()
     _, err := wskdeploy.Deploy(manifestPath, deploymentPath)
     assert.Equal(t, nil, err, "Failed to deploy based on the manifest and deployment files.")
@@ -39,6 +37,6 @@ func TestDependency(t *testing.T) {
 }
 
 var (
-    manifestPath   = os.Getenv("GOPATH") + "/src/github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/dependency/manifest.yaml"
-    deploymentPath = ""
+    manifestPath   = os.Getenv("GOPATH") + "/src/github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/zipaction/manifest.yml"
+    deploymentPath = os.Getenv("GOPATH") + "/src/github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/zipaction/deployment.yml"
 )


### PR DESCRIPTION
In the new way to load the credentials, we are now able to run the
following integration tests:
* jaractionTest
* triggerrulTest
* zipactionTest
* flagsTest

We have to adopt a new model to create the integration tests and run
them in a consolidated test file, in order to avoid the concurrent
issues of accessing the same resources in openwhisk at the same time.

Closes-Bug: #398