### PR TITLE
fixing david's runtimetests

### DIFF
--- a/tests/src/integration/common/wskdeploy.go
+++ b/tests/src/integration/common/wskdeploy.go
@@ -91,9 +91,9 @@ func (wskdeploy *Wskdeploy) UndeployProjectPathOnly(projectPath string) ([]byte,
 }
 
 func (wskdeploy *Wskdeploy) DeployManifestPathOnly(manifestpath string) ([]byte, error) {
-	return wskdeploy.RunCommand("-p", manifestpath)
+	return wskdeploy.RunCommand("-m", manifestpath)
 }
 
 func (wskdeploy *Wskdeploy) UndeployManifestPathOnly(manifestpath string) ([]byte, error) {
-    return wskdeploy.RunCommand("undeploy", "-p", manifestpath)
+    return wskdeploy.RunCommand("undeploy", "-m", manifestpath)
 }

--- a/tests/src/integration/common/wskdeploy.go
+++ b/tests/src/integration/common/wskdeploy.go
@@ -91,9 +91,9 @@ func (wskdeploy *Wskdeploy) UndeployProjectPathOnly(projectPath string) ([]byte,
 }
 
 func (wskdeploy *Wskdeploy) DeployManifestPathOnly(manifestpath string) ([]byte, error) {
-	return wskdeploy.RunCommand("-m", manifestpath)
+	return wskdeploy.RunCommand("-p", manifestpath)
 }
 
 func (wskdeploy *Wskdeploy) UndeployManifestPathOnly(manifestpath string) ([]byte, error) {
-    return wskdeploy.RunCommand("undeploy", "-m", manifestpath)
+    return wskdeploy.RunCommand("undeploy", "-p", manifestpath)
 }

--- a/tests/src/integration/runtimetests/manifest.yaml
+++ b/tests/src/integration/runtimetests/manifest.yaml
@@ -1,5 +1,5 @@
 package:
-  name: helloworld
+  name: TestExplicitRuntimes
   version: 1.0
   license: Apache-2.0
   actions:
@@ -86,10 +86,6 @@ package:
     helloworldjava:
       function: src/hello.jar
       runtime: java
-      main: Hello
-    helloworldinvalid:
-      function: src/hello.jar
-      runtime: invalid
       main: Hello
   triggers:
     locationUpdate:

--- a/tests/src/integration/runtimetests/manifest.yml
+++ b/tests/src/integration/runtimetests/manifest.yml
@@ -13,93 +13,84 @@ package:
         place: string
       outputs:
         payload: string
-  actions:
-      greetingphp:
-        web-export: true
-        version: 1.0
-        function: src/hello.php
-        runtime: php:7.1
-        inputs:
-          name: string
-          place: string
-        outputs:
-          payload: string
-  actions:
-        greetingpython:
-          web-export: true
-          version: 1.0
-          function: src/hello.py
-          runtime: python
-          inputs:
-            name: string
-            place: string
-          outputs:
-            payload: string
-  actions:
-          greetingpython:
-            web-export: true
-            version: 1.0
-            function: src/hello.py
-            runtime: python:2
-            inputs:
-              name: string
-              place: string
-            outputs:
-              payload: string
-  actions:
-          greetingpython:
-            web-export: true
-            version: 1.0
-            function: src/hello.py
-            runtime: python:3
-            inputs:
-              name: string
-              place: string
-            outputs:
-              payload: string
-  actions:
-          greetingswift:
-            web-export: true
-            version: 1.0
-            function: src/hello.swift
-            runtime: swift:3.1.1
-            inputs:
-              name: string
-              place: string
-            outputs:
-              payload: string
-  actions:
-            greetingswift:
-              web-export: true
-              version: 1.0
-              function: src/hello.swift
-              runtime: swift
-              inputs:
-                name: string
-                place: string
-              outputs:
-                payload: string
-  actions:
-            greetingswift:
-              web-export: true
-              version: 1.0
-              function: src/hello.swift
-              runtime: swift:3
-              inputs:
-                name: string
-                place: string
-              outputs:
-                payload: string
-  actions:
-          helloworldjava:
-            function: src/hello.jar
-            runtime: java
-            main: Hello
-  actions:
-            helloworldinvalid:
-              function: src/hello.jar
-              runtime: invalid
-              main: Hello
+    greetingphp:
+      web-export: true
+      version: 1.0
+      function: src/hello.php
+      runtime: php:7.1
+      inputs:
+        name: string
+        place: string
+      outputs:
+        payload: string
+    greetingpython:
+      web-export: true
+      version: 1.0
+      function: src/hello.py
+      runtime: python
+      inputs:
+        name: string
+        place: string
+      outputs:
+        payload: string
+    greetingpython:
+      web-export: true
+      version: 1.0
+      function: src/hello.py
+      runtime: python:2
+      inputs:
+        name: string
+        place: string
+      outputs:
+        payload: string
+    greetingpython:
+      web-export: true
+      version: 1.0
+      function: src/hello.py
+      runtime: python:3
+      inputs:
+        name: string
+        place: string
+      outputs:
+        payload: string
+    greetingswift:
+      web-export: true
+      version: 1.0
+      function: src/hello.swift
+      runtime: swift:3.1.1
+      inputs:
+        name: string
+        place: string
+      outputs:
+        payload: string
+    greetingswift:
+      web-export: true
+      version: 1.0
+      function: src/hello.swift
+      runtime: swift
+      inputs:
+        name: string
+        place: string
+      outputs:
+        payload: string
+    greetingswift:
+      web-export: true
+      version: 1.0
+      function: src/hello.swift
+      runtime: swift:3
+      inputs:
+        name: string
+        place: string
+      outputs:
+        payload: string
+    helloworldjava:
+      function: src/hello.jar
+      runtime: java
+      main: Hello
+    helloworldinvalid:
+      function: src/hello.jar
+      runtime: invalid
+      main: Hello
   triggers:
     locationUpdate:
   rules:

--- a/tests/src/integration/runtimetests/runtimes_test.go
+++ b/tests/src/integration/runtimetests/runtimes_test.go
@@ -30,8 +30,10 @@ var wskprops = common.GetWskprops()
 
 func TestExplicitRunTimes(t *testing.T) {
 	wskdeploy := common.NewWskdeploy()
-	manifestPath := os.Getenv("GOPATH") + "/src/github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/runtimetests"
-	_, err := wskdeploy.DeployProjectPathOnly(manifestPath)
-	assert.Equal(t, nil, err, "Failed to deploy based on the manifest path")
+	projectPath := os.Getenv("GOPATH") + "/src/github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/runtimetests"
+	_, err := wskdeploy.DeployProjectPathOnly(projectPath)
+	assert.Equal(t, nil, err, "Failed to deploy based on the project path")
+	_, err := wskdeploy.UnDeployProjectPathOnly(projectPath)
+	assert.Equal(t, nil, err, "Failed to undeploy based on the project path")
 }
 

--- a/tests/src/integration/runtimetests/runtimes_test.go
+++ b/tests/src/integration/runtimetests/runtimes_test.go
@@ -28,11 +28,10 @@ import (
 
 var wskprops = common.GetWskprops()
 
-func TestSupportProjectPath(t *testing.T) {
-	os.Setenv("__OW_API_HOST", wskprops.APIHost)
+func TestExplicitRunTimes(t *testing.T) {
 	wskdeploy := common.NewWskdeploy()
 	manifestPath := os.Getenv("GOPATH") + "/src/github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/runtimetests"
-	_, err := wskdeploy.DeployManifestPathOnly(manifestPath)
+	_, err := wskdeploy.DeployProjectPathOnly(manifestPath)
 	assert.Equal(t, nil, err, "Failed to deploy based on the manifest path")
 }
 

--- a/tests/src/integration/runtimetests/runtimes_test.go
+++ b/tests/src/integration/runtimetests/runtimes_test.go
@@ -28,12 +28,12 @@ import (
 
 var wskprops = common.GetWskprops()
 
-func TestExplicitRunTimes(t *testing.T) {
+func TestExplicitRuntimes(t *testing.T) {
 	wskdeploy := common.NewWskdeploy()
 	projectPath := os.Getenv("GOPATH") + "/src/github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/runtimetests"
 	_, err := wskdeploy.DeployProjectPathOnly(projectPath)
 	assert.Equal(t, nil, err, "Failed to deploy based on the project path")
-	_, err := wskdeploy.UnDeployProjectPathOnly(projectPath)
+	_, err = wskdeploy.UndeployProjectPathOnly(projectPath)
 	assert.Equal(t, nil, err, "Failed to undeploy based on the project path")
 }
 


### PR DESCRIPTION
Fix 1: Instead of calling `DeployManifestPathOnly`,  using `DeployProjectPathOnly`
Fix 2: Updating manifest file to remove unnecessary `actions` field
Fix 3: Renaming integration test from `TestSupportProjectPath` to `TestExplicitRuntimes` as `TestSupportProjectPath` is overlapping with one of the tests from flagtests.