### PR TITLE
Print warning msg when env var is empty

### DIFF
--- a/tests/usecases/triggerrule/manifest.yml
+++ b/tests/usecases/triggerrule/manifest.yml
@@ -1,5 +1,5 @@
 package:
-  name: helloworld
+  name: triggerrule
   version: 1.0
   license: Apache-2.0
   actions:

--- a/utils/misc.go
+++ b/utils/misc.go
@@ -159,8 +159,9 @@ func GetEnvVar(key interface{}) interface{} {
 			envkey := strings.Split(key.(string), "$")[1]
 			value := os.Getenv(envkey)
 			if value == "" {
-				// TODO() We should issue a warning to the user (verbose) that env. var. was not found
+				// Issue a warning to the user (verbose) that env. var. was not found
 				// (i.e., and empty string was returned).
+				fmt.Println("WARNING: Missing Environment Variable "+envkey+".")
 			}
 			return value
 		}


### PR DESCRIPTION
Fix issue #399 

This PR will print warning messages if the env variable is empty. Here is a sample:

```
2017/08/31 03:40:51 WARNING: Missing Environment Variable CLOUDANT_HOSTNAME.
```

This PR also fixed the wrong package name in manifest in use case `triggerrule`. In the current source code of use case `triggerrule`, the package name in deployment (`triggerrule`) is different than in manifest (`helloworld`), which will remove following warning information while deployment and will cause incorrect deployment. 
```
2017/08/31 03:27:41 WARNING: Package name in deployment file triggerrule does not match with manifest file.
```