### PR TITLE
Fixing undeployment with yml

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -156,19 +156,19 @@ func Deploy() error {
 		if _, err := os.Stat(path.Join(projectPath, utils.ManifestFileNameYaml)); err == nil {
 			utils.Flags.ManifestPath = path.Join(projectPath, utils.ManifestFileNameYaml)
 			log.Printf("Using %s for deployment \n", utils.Flags.ManifestPath)
-		} else if _, err := os.Stat(path.Join(projectPath, utils.ManifestFileNameYaml)); err == nil {
+		} else if _, err := os.Stat(path.Join(projectPath, utils.ManifestFileNameYml)); err == nil {
 			utils.Flags.ManifestPath = path.Join(projectPath, utils.ManifestFileNameYml)
 			log.Printf("Using %s for deployment", utils.Flags.ManifestPath)
 		} else {
 			log.Printf("Manifest file not found at path %s", projectPath)
-			return errors.New("missing manifest.yaml file")
+			return errors.New("missing "+utils.ManifestFileNameYaml+"/" +utils.ManifestFileNameYml+" file")
 		}
 	}
 
 	if utils.Flags.DeploymentPath == "" {
-		if _, err := os.Stat(path.Join(projectPath, "deployment.yaml")); err == nil {
+		if _, err := os.Stat(path.Join(projectPath, utils.DeploymentFileNameYaml)); err == nil {
 			utils.Flags.DeploymentPath = path.Join(projectPath, utils.DeploymentFileNameYaml)
-		} else if _, err := os.Stat(path.Join(projectPath, "deployment.yml")); err == nil {
+		} else if _, err := os.Stat(path.Join(projectPath, utils.DeploymentFileNameYml)); err == nil {
 			utils.Flags.DeploymentPath = path.Join(projectPath, utils.DeploymentFileNameYml)
 		}
 	}
@@ -211,12 +211,11 @@ func Deploy() error {
 
 	} else {
 		if utils.Flags.WithinOpenWhisk {
-			utils.PrintOpenWhiskError(wski18n.T("missing manifest.yaml file"))
-			return errors.New("missing manifest.yaml file")
+			utils.PrintOpenWhiskError(wski18n.T("missing "+utils.ManifestFileNameYaml+"/" +utils.ManifestFileNameYml+" file"))
 		} else {
-			log.Println("missing manifest.yaml file")
-			return errors.New("missing manifest.yaml file")
+			log.Println("missing "+utils.ManifestFileNameYaml+"/" +utils.ManifestFileNameYml+" file")
 		}
+		return errors.New("missing "+utils.ManifestFileNameYaml+"/" +utils.ManifestFileNameYml+" file")
 	}
 
 }
@@ -225,22 +224,30 @@ func Undeploy() error {
 	// TODO: Work your own magic here
 	whisk.SetVerbose(utils.Flags.Verbose)
 
-	if utils.Flags.ManifestPath == "" {
-		if ok, _ := regexp.Match(utils.ManifestFileNameYml, []byte(utils.Flags.ManifestPath)); ok {
-			utils.Flags.ManifestPath = path.Join(utils.Flags.ProjectPath, utils.ManifestFileNameYml)
-		} else {
-			utils.Flags.ManifestPath = path.Join(utils.Flags.ProjectPath, utils.ManifestFileNameYaml)
-		}
+	projectPath, err := filepath.Abs(utils.Flags.ProjectPath)
+	utils.Check(err)
 
+	if utils.Flags.ManifestPath == "" {
+		if _, err := os.Stat(path.Join(projectPath, utils.ManifestFileNameYaml)); err == nil {
+			utils.Flags.ManifestPath = path.Join(projectPath, utils.ManifestFileNameYaml)
+			log.Printf("Using %s for undeployment \n", utils.Flags.ManifestPath)
+		} else if _, err := os.Stat(path.Join(projectPath, utils.ManifestFileNameYml)); err == nil {
+			utils.Flags.ManifestPath = path.Join(projectPath, utils.ManifestFileNameYml)
+			log.Printf("Using %s for undeployment", utils.Flags.ManifestPath)
+		} else {
+			log.Printf("Manifest file not found at path %s", projectPath)
+			return errors.New("missing "+utils.ManifestFileNameYaml+"/" +utils.ManifestFileNameYml+" file")
+		}
 	}
 
 	if utils.Flags.DeploymentPath == "" {
-		if ok, _ := regexp.Match(utils.DeploymentFileNameYml, []byte(utils.Flags.ManifestPath)); ok {
-			utils.Flags.DeploymentPath = path.Join(utils.Flags.ProjectPath, utils.DeploymentFileNameYml)
-		} else {
-			utils.Flags.DeploymentPath = path.Join(utils.Flags.ProjectPath, utils.DeploymentFileNameYaml)
+		if _, err := os.Stat(path.Join(projectPath, utils.DeploymentFileNameYaml)); err == nil {
+			utils.Flags.DeploymentPath = path.Join(projectPath, utils.DeploymentFileNameYaml)
+			log.Printf("Using %s for undeployment \n", utils.Flags.DeploymentPath)
+		} else if _, err := os.Stat(path.Join(projectPath, utils.DeploymentFileNameYml)); err == nil {
+			utils.Flags.DeploymentPath = path.Join(projectPath, utils.DeploymentFileNameYml)
+			log.Printf("Using %s for undeployment \n", utils.Flags.DeploymentPath)
 		}
-
 	}
 
 	if utils.FileExists(utils.Flags.ManifestPath) {
@@ -267,7 +274,7 @@ func Undeploy() error {
 		}
 
 	} else {
-		log.Println("missing manifest.yaml file")
-		return errors.New("missing manifest.yaml file")
+		log.Println("missing "+utils.ManifestFileNameYaml+"/" +utils.ManifestFileNameYml+" file")
+		return errors.New("missing "+utils.ManifestFileNameYaml+"/" +utils.ManifestFileNameYml+" file")
 	}
 }

--- a/deployers/whiskclient.go
+++ b/deployers/whiskclient.go
@@ -28,13 +28,12 @@ import (
 	"github.com/apache/incubator-openwhisk-client-go/whisk"
 	"github.com/apache/incubator-openwhisk-wskdeploy/parsers"
 	"github.com/apache/incubator-openwhisk-wskdeploy/utils"
-    "errors"
-    "log"
+        "errors"
+        "log"
+    "path"
 )
 
 const (
-    DEPLOYMENTFILE = "deployment.yml"
-    MANIDESTFILE = "manifest.yml"
     COMMANDLINE = "wskdeploy command line"
     DEFAULTVALUE = "default value"
     WSKPROPS = ".wskprops"
@@ -81,20 +80,20 @@ func NewWhiskClient(proppath string, deploymentPath string, manifestPath string,
         mm := parsers.NewYAMLParser()
         deployment := mm.ParseDeployment(deploymentPath)
         credential.Value = deployment.Application.Credential
-        credential.Source = DEPLOYMENTFILE
+        credential.Source = path.Base(deploymentPath)
         namespace.Value = deployment.Application.Namespace
-        namespace.Source = DEPLOYMENTFILE
+        namespace.Source = path.Base(deploymentPath)
         apiHost.Value = deployment.Application.ApiHost
-        apiHost.Source = DEPLOYMENTFILE
+        apiHost.Source = path.Base(deploymentPath)
     }
 
     if len(credential.Value) == 0 || len(namespace.Value) == 0 || len(apiHost.Value) == 0 {
         if utils.FileExists(manifestPath) {
             mm := parsers.NewYAMLParser()
             manifest := mm.ParseManifest(manifestPath)
-            credential = GetPropertyValue(credential, manifest.Package.Credential, MANIDESTFILE)
-            namespace = GetPropertyValue(namespace, manifest.Package.Namespace, MANIDESTFILE)
-            apiHost = GetPropertyValue(apiHost, manifest.Package.ApiHost, MANIDESTFILE)
+            credential = GetPropertyValue(credential, manifest.Package.Credential, path.Base(manifestPath))
+            namespace = GetPropertyValue(namespace, manifest.Package.Namespace, path.Base(manifestPath))
+            apiHost = GetPropertyValue(apiHost, manifest.Package.ApiHost, path.Base(manifestPath))
         }
     }
 


### PR DESCRIPTION
Closes #409 
Closes #415 

**Fix 1: added support to undeploy with `-p`**

Before:

```
./wskdeploy undeploy -p tests/src/integration/zipaction/
2017/08/31 08:55:21 failed get openwhisk info from internet
2017/08/31 08:55:21 Start unmarshal Openwhisk info from local values
2017/08/31 08:55:21 missing manifest.yaml file
```

After:

```
./wskdeploy undeploy -p tests/src/integration/zipaction/
2017/08/31 09:45:26 failed get openwhisk info from internet
2017/08/31 09:45:26 Start unmarshal Openwhisk info from local values
2017/08/31 09:45:26 Using /Users/pritidesai/Documents/goworkspace/src/github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/zipaction/manifest.yml for undeployment
2017/08/31 09:45:26 Using /Users/pritidesai/Documents/goworkspace/src/github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/zipaction/deployment.yml for undeployment 
2017/08/31 09:45:26 The URL is https://openwhisk.ng.bluemix.net/api, selected from .wskprops
2017/08/31 09:45:26 The auth key is set, selected from .wskprops
2017/08/31 09:45:26 The namespace is pdesai@us.ibm.com_dev, selected from .wskprops
Removing action zipaction/cat ... Done!
Removing package zipaction ... Done!

Deployment removed successfully.
```

**Fix 2: Removing all hardcoded manifest.yaml, manifest.yml, deployment.yaml, and deployment.yml**

```
$ grep -r "\"deployment.yml" . --include=*.go
./utils/misc.go:const DeploymentFileNameYml = "deployment.yml"

$ grep -r "\"deployment.yaml" . --include=*.go
./utils/misc.go:const DeploymentFileNameYaml = "deployment.yaml"

$ grep -r "\"manifest.yml" . --include=*.go
./utils/misc.go:const ManifestFileNameYml = "manifest.yml"

$ grep -r "\"manifest.yaml" . --include=*.go
./utils/misc.go:const ManifestFileNameYaml = "manifest.yaml"
```

**Fix 3: hardcoded manifest.yml  and deployment.yml in Whisk client and as a result reporting credentials are read from manifest.yml even when credentials are read from manifest.yaml**

Before:

```
./wskdeploy -m tests/src/integration/zipaction/manifest.yaml 
2017/08/31 09:51:28 failed get openwhisk info from internet
2017/08/31 09:51:28 Start unmarshal Openwhisk info from local values
2017/08/31 09:51:28 The URL is https://openwhisk.ng.bluemix.net/api, selected from .wskprops
2017/08/31 09:51:28 The auth key is set, selected from .wskprops
2017/08/31 09:51:28 The namespace is ***, selected from manifest.yml
2017/08/31 09:51:28 Deploying package zipaction ... 
2017/08/31 09:51:28 Done!
2017/08/31 09:51:28 Deploying action zipaction/cat ... 
2017/08/31 09:51:28 Done!
2017/08/31 09:51:28 
Deployment completed successfully.
```

After:

```
./wskdeploy -m tests/src/integration/zipaction/manifest.yaml
2017/08/31 09:46:33 failed get openwhisk info from internet
2017/08/31 09:46:33 Start unmarshal Openwhisk info from local values
2017/08/31 09:46:33 Using /Users/pritidesai/Documents/goworkspace/src/github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/zipaction/manifest.yml for deployment
2017/08/31 09:46:33 The URL is https://openwhisk.ng.bluemix.net/api, selected from .wskprops
2017/08/31 09:46:33 The auth key is set, selected from .wskprops
2017/08/31 09:46:33 The namespace is ****, selected from manifest.yml
```

**Fix 4: Deployment with manifest.yml**

Before:

```
ls -1 tests/src/integration/zipaction/
actions/
deployment.yml
manifest.yml
zipaction_test.go

./wskdeploy -p tests/src/integration/zipaction/
2017/08/31 09:48:21 failed get openwhisk info from internet
2017/08/31 09:48:21 Start unmarshal Openwhisk info from local values
2017/08/31 09:48:21 Manifest file not found at path /Users/pritidesai/Documents/goworkspace/src/github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/zipaction

```

After:

```
./wskdeploy -p tests/src/integration/zipaction/
2017/08/31 10:03:56 failed get openwhisk info from internet
2017/08/31 10:03:56 Start unmarshal Openwhisk info from local values
2017/08/31 10:03:56 Using /Users/pritidesai/Documents/goworkspace/src/github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/zipaction/manifest.yaml for deployment 
2017/08/31 10:03:56 The URL is https://openwhisk.ng.bluemix.net/api, selected from .wskprops
2017/08/31 10:03:56 The auth key is set, selected from .wskprops
2017/08/31 10:03:56 The namespace is ****, selected from manifest.yaml
2017/08/31 10:03:56 Deploying package zipaction ... 
2017/08/31 10:03:57 Done!
2017/08/31 10:03:57 Deploying action zipaction/cat ... 
2017/08/31 10:03:57 Done!
2017/08/31 10:03:57 
Deployment completed successfully.
```
