### PR TITLE
deprecating swift and php runtimes

### DIFF
--- a/parsers/manifest_parser.go
+++ b/parsers/manifest_parser.go
@@ -267,7 +267,7 @@ func (dm *YAMLParser) ComposeActions(mani *ManifestYAML, manipath string) (ar []
 
 				switch ext {
 				case ".swift":
-					kind = "swift"
+					kind = "swift:3"
 				case ".js":
 					kind = "nodejs:6"
 				case ".py":
@@ -275,7 +275,7 @@ func (dm *YAMLParser) ComposeActions(mani *ManifestYAML, manipath string) (ar []
 				case ".java":
 					kind = "java"
 				case ".php":
-					kind = "php"
+					kind = "php:7.1"
 				case ".jar":
 					kind = "java"
 				default:

--- a/parsers/manifest_parser_test.go
+++ b/parsers/manifest_parser_test.go
@@ -500,16 +500,12 @@ func TestComposeActionsForImplicitRuntimes(t *testing.T) {
 				for i := 0; i < len(actions); i++ {
 					if actions[i].Action.Name == "helloNodejs" {
 						expectedResult = "nodejs:6"
-						// (TODO) change expectedResult in the following condition
-						// (TODO) once issue #306 is fixed as runtime is set to
-						// (TODO) nodejs:default for any kind of action file except
-						// (TODO) files with extension .js, .py, and .swift
 					} else if actions[i].Action.Name == "helloJava" {
 						expectedResult = "java"
 					} else if actions[i].Action.Name == "helloPython" {
 						expectedResult = "python"
 					} else if actions[i].Action.Name == "helloSwift" {
-						expectedResult = "swift"
+						expectedResult = "swift:3"
 					}
 					actualResult := actions[i].Action.Exec.Kind
 					assert.Equal(t, expectedResult, actualResult, "Expected "+expectedResult+" but got "+actualResult)

--- a/tests/src/integration/runtimetests/manifest.yaml
+++ b/tests/src/integration/runtimetests/manifest.yaml
@@ -3,7 +3,7 @@ package:
   version: 1.0
   license: Apache-2.0
   actions:
-    greeting:
+    greetingnodejs-with-explicit-runtime:
       web-export: true
       version: 1.0
       function: src/greeting.js
@@ -13,7 +13,16 @@ package:
         place: string
       outputs:
         payload: string
-    greetingphp:
+    greetingnodejs-without-explicit-runtime:
+      web-export: true
+      version: 1.0
+      function: src/greeting.js
+      inputs:
+        name: string
+        place: string
+      outputs:
+        payload: string
+    greetingphp-with-explicit-runtime:
       web-export: true
       version: 1.0
       function: src/hello.php
@@ -23,7 +32,16 @@ package:
         place: string
       outputs:
         payload: string
-    greetingpython:
+    greetingphp-without-explicit-runtime:
+      web-export: true
+      version: 1.0
+      function: src/hello.php
+      inputs:
+        name: string
+        place: string
+      outputs:
+        payload: string
+    greetingpython-with-explicit-runtime:
       web-export: true
       version: 1.0
       function: src/hello.py
@@ -33,7 +51,16 @@ package:
         place: string
       outputs:
         payload: string
-    greetingpython:
+    greetingpython-without-explicit-runtime:
+      web-export: true
+      version: 1.0
+      function: src/hello.py
+      inputs:
+        name: string
+        place: string
+      outputs:
+        payload: string
+    greetingpython2-with-explicit-runtime:
       web-export: true
       version: 1.0
       function: src/hello.py
@@ -43,7 +70,7 @@ package:
         place: string
       outputs:
         payload: string
-    greetingpython:
+    greetingpython3-with-explicit-runtime:
       web-export: true
       version: 1.0
       function: src/hello.py
@@ -53,7 +80,7 @@ package:
         place: string
       outputs:
         payload: string
-    greetingswift:
+    greetingswift311-with-explicit-runtime:
       web-export: true
       version: 1.0
       function: src/hello.swift
@@ -63,17 +90,7 @@ package:
         place: string
       outputs:
         payload: string
-    greetingswift:
-      web-export: true
-      version: 1.0
-      function: src/hello.swift
-      runtime: swift
-      inputs:
-        name: string
-        place: string
-      outputs:
-        payload: string
-    greetingswift:
+    greetingswift3-with-explicit-runtime:
       web-export: true
       version: 1.0
       function: src/hello.swift
@@ -83,15 +100,25 @@ package:
         place: string
       outputs:
         payload: string
-    helloworldjava:
+    greetingswift-without-explicit-runtime:
+      web-export: true
+      version: 1.0
+      function: src/hello.swift
+      inputs:
+        name: string
+        place: string
+      outputs:
+        payload: string
+    helloworldjava-with-explicit-runtime:
       function: src/hello.jar
       runtime: java
+      main: Hello
+    helloworldjava-without-explicit-runtime:
+      function: src/hello.jar
       main: Hello
   triggers:
     locationUpdateRuntime:
   rules:
     myRuleRuntime:
       trigger: locationUpdateRuntime
-      #the action name and the action file greeting.js should consistent.
-      #currently the implementation deside the action name consistent with action file name?
       action: greeting

--- a/utils/misc.go
+++ b/utils/misc.go
@@ -490,11 +490,12 @@ func ParseOpenWhisk(apiHost string) (op OpenWhiskInfo, err error) {
 
 func ConvertToMap(op OpenWhiskInfo) (rt map[string][]string) {
 	rt = make(map[string][]string)
-	for k, _ := range op.Runtimes {
-		v := op.Runtimes[k]
+	for k, v := range op.Runtimes {
 		rt[k] = make([]string, 0, len(v))
-		for i := range op.Runtimes[k] {
-			rt[k] = append(rt[k], op.Runtimes[k][i].Kind)
+		for i := range v {
+			if (!v[i].Deprecated) {
+				rt[k] = append(rt[k], v[i].Kind)
+			}
 		}
 	}
 	return


### PR DESCRIPTION
we have swift:3, swift:3.1.1, and php:7.1 supported.

Implicit runtimes `swift` and `php` are not supported, replacing them with `swift:3` and `php:7.1`.

Action creation fails with this message when implicit runtime is set to `php`:

```
"error":"The request content was malformed:\nkind 'php' not in Set(php:7.1, swift:3, nodejs, blackbox, java, sequence, nodejs:6, python:3, python, python:2, swift, swift:3.1.1)","code":9942234}
```


Closes #429 

