### PR TITLE
Enable sub directory in git repo as a dependency project

### DIFF
--- a/deployers/servicedeployer.go
+++ b/deployers/servicedeployer.go
@@ -840,8 +840,11 @@ func (deployer *ServiceDeployer) printDeploymentAssets(assets *DeploymentApplica
 func (deployer *ServiceDeployer) getDependentDeployer(depName string, depRecord utils.DependencyRecord) (*ServiceDeployer, error) {
 	depServiceDeployer := NewServiceDeployer()
 	projectPath := path.Join(depRecord.ProjectPath, depName+"-"+depRecord.Version)
-	manifestPath := path.Join(projectPath, utils.ManifestFileNameYml)
-	deploymentPath := path.Join(projectPath, utils.DeploymentFileNameYaml)
+	if len(depRecord.SubFolder)>0 {
+		projectPath = path.Join(projectPath,depRecord.SubFolder)
+	}
+	manifestPath := utils.GetManifestFilePath(projectPath)
+	deploymentPath := utils.GetDeploymentFilePath(projectPath)
 	depServiceDeployer.ProjectPath = projectPath
 	depServiceDeployer.ManifestPath = manifestPath
 	depServiceDeployer.DeploymentPath = deploymentPath

--- a/parsers/manifest_parser.go
+++ b/parsers/manifest_parser.go
@@ -146,7 +146,7 @@ func (dm *YAMLParser) ComposeDependencies(mani *ManifestYAML, projectPath string
 		}
 
 		packDir := path.Join(projectPath, "Packages")
-		depMap[key] = utils.DependencyRecord{packDir, mani.Package.Packagename, location, version, keyValArrParams, keyValArrAnot, isBinding}
+		depMap[key] = utils.NewDependencyRecord(packDir, mani.Package.Packagename, location, version, keyValArrParams, keyValArrAnot, isBinding)
 	}
 
 	return depMap, nil

--- a/tests/usecases/dependency/manifest.yaml
+++ b/tests/usecases/dependency/manifest.yaml
@@ -3,6 +3,8 @@ package:
   dependencies:
     hellowhisk:
       location: github.com/paulcastro/hellowhisk
+    myhelloworld:
+      location: github.com/daisy-ycguo/wskdeploy-test/helloworld
     myCloudant:
       location: /whisk.system/cloudant
       inputs:
@@ -11,7 +13,7 @@ package:
         myAnnotation: Here it is
   sequences:
     mySequence:
-      actions: hellowhisk/greeting, hellowhisk/httpGet
+      actions: hellowhisk/greeting, hellowhisk/httpGet, myhelloworld/helloworld
   triggers:
     myTrigger:
   rules:

--- a/utils/dependencies.go
+++ b/utils/dependencies.go
@@ -24,13 +24,44 @@ import (
 )
 
 type DependencyRecord struct {
-	ProjectPath string
-	Packagename string
-	Location    string
-	Version     string
+	ProjectPath string	//root of the source codes of dependent projects, e.g. src_project_path/Packages
+	Packagename string	//name of the package
+	Location    string	//location
+	Version     string	//version
 	Parameters  whisk.KeyValueArr
 	Annotations whisk.KeyValueArr
 	IsBinding   bool
+	BaseRepo    string
+	SubFolder   string
+}
+
+func NewDependencyRecord(projectPath string,
+			packagename string,
+			location string,
+			version string,
+			parameters whisk.KeyValueArr,
+			annotations whisk.KeyValueArr,
+			isBinding bool) DependencyRecord {
+	var record DependencyRecord
+	record.ProjectPath = projectPath
+	record.Packagename = packagename
+	record.Location = location
+	record.Version = version
+	record.Parameters = parameters
+	record.Annotations = annotations
+	record.IsBinding = isBinding
+	//split url to BaseUrl and SubFolder
+	if !record.IsBinding {
+		paths := strings.Split(location, "/")
+		record.BaseRepo = strings.Join([]string{paths[0],paths[1],paths[2],paths[3],paths[4]},"/")
+		if len(paths)>5 {
+			record.SubFolder = strings.TrimPrefix(record.Location,record.BaseRepo)
+		} else {
+			record.SubFolder = ""
+		}
+	}
+
+	return record
 }
 
 func LocationIsBinding(location string) bool {
@@ -48,3 +79,4 @@ func LocationIsGithub(location string) bool {
 
 	return false
 }
+

--- a/utils/gitreader.go
+++ b/utils/gitreader.go
@@ -29,19 +29,20 @@ import (
 )
 
 type GitReader struct {
-	Name        string
-	Url         string
+	Name        string	// the name of the dependency
+	Url         string	// pkg repo location, e.g. github.com/user/repo
+	//BaseRepo    string	// base url of the git repo, e.g. github.com/user/repo
+	//SubFolder   string	// subfolder of the package under BaseUrl
 	Version     string
-	ProjectPath string
+	ProjectPath string	// The root folder of all dependency packages, e.g. src_project_path/Packages
 }
 
 func NewGitReader(projectName string, record DependencyRecord) *GitReader {
 	var gitReader GitReader
 
 	gitReader.Name = projectName
-	gitReader.Url = record.Location
+	gitReader.Url = record.BaseRepo
 	gitReader.Version = record.Version
-
 	gitReader.ProjectPath = record.ProjectPath
 
 	return &gitReader
@@ -68,7 +69,7 @@ func (reader *GitReader) CloneDependency() error {
 	Check(err)
 
 	u, err := url.Parse(reader.Url)
-	team, project := path.Split(u.Path)
+	team, _ := path.Split(u.Path)
 
 	team = strings.TrimPrefix(team, "/")
 	team = strings.TrimSuffix(team, "/")
@@ -95,7 +96,11 @@ func (reader *GitReader) CloneDependency() error {
 	}
 
 	rootDir := filepath.Join(reader.ProjectPath, zipReader.File[0].Name)
-	depPath := filepath.Join(reader.ProjectPath, project+"-"+reader.Version)
+	depPath := filepath.Join(reader.ProjectPath, reader.Name+"-"+reader.Version)
+	//if the folder exists, remove it at first
+	if _, err := os.Stat(depPath); err == nil {
+		os.Remove(depPath)
+	}
 	os.Rename(rootDir, depPath)
 	os.Remove(filepath.Join(reader.ProjectPath, zipFileName))
 

--- a/utils/misc.go
+++ b/utils/misc.go
@@ -38,6 +38,7 @@ import (
 	"github.com/hokaccha/go-prettyjson"
 	"io/ioutil"
 	"net/http"
+	"path"
 )
 
 // ActionRecord is a container to keep track of
@@ -595,6 +596,26 @@ func CheckExistRuntime(rtname string, rts map[string][]string) bool {
 		}
 	}
 	return false
+}
+
+func GetManifestFilePath(projectPath string) string {
+	if _, err := os.Stat(path.Join(projectPath, ManifestFileNameYaml)); err == nil {
+		return path.Join(projectPath, ManifestFileNameYaml)
+	} else if _, err := os.Stat(path.Join(projectPath, ManifestFileNameYml)); err == nil {
+		return path.Join(projectPath, ManifestFileNameYml)
+	} else {
+		return ""
+	}
+}
+
+func GetDeploymentFilePath(projectPath string) string {
+	if _, err := os.Stat(path.Join(projectPath, DeploymentFileNameYaml)); err == nil {
+		return path.Join(projectPath, DeploymentFileNameYaml)
+	} else if _, err := os.Stat(path.Join(projectPath, DeploymentFileNameYml)); err == nil {
+		return path.Join(projectPath, DeploymentFileNameYml)
+	} else {
+		return ""
+	}
 }
 
 // name of manifest and deployment files

--- a/utils/util_test.go
+++ b/utils/util_test.go
@@ -60,3 +60,17 @@ func TestGetEnvVar(t *testing.T) {
 	assert.Equal(t, "5000", GetEnvVar("5000"), "Should be no difference between integer and string.")
 	assert.Equal(t, "", GetEnvVar("$WithDollarAgain"), "if not found in environemnt, return empty string.")
 }
+
+func TestDependencies(t *testing.T) {
+	var record = NewDependencyRecord("projectPath","packageName","http://github.com/user/repo","master",nil,nil,false)
+	assert.Equal(t, "projectPath", record.ProjectPath,"ProjectPath is wrong")
+	assert.Equal(t, "http://github.com/user/repo", record.Location, "URL is wrong")
+	assert.Equal(t, "http://github.com/user/repo", record.BaseRepo, "BaseRepo is wrong")
+	assert.Equal(t, "", record.SubFolder, "SubFolder is wrong")
+
+	record = NewDependencyRecord("projectPath","packageName","http://github.com/user/repo/subfolder1/subfolder2","master",nil,nil,false)
+	assert.Equal(t, "projectPath", record.ProjectPath,"ProjectPath is wrong")
+	assert.Equal(t, "http://github.com/user/repo/subfolder1/subfolder2", record.Location, "URL is wrong")
+	assert.Equal(t, "http://github.com/user/repo", record.BaseRepo, "BaseRepo is wrong")
+	assert.Equal(t, "/subfolder1/subfolder2", record.SubFolder, "SubFolder is wrong")
+}


### PR DESCRIPTION
Address issue #430 

It can be tested by:
```
./wskdeploy -m tests/usecases/dependency/manifest.yaml
```

In this use case, a new dependency to a sub directory of a repo is added, in order to test the function.
```
package:
  name: opentest
  dependencies:
    myhelloworld:
      location: github.com/daisy-ycguo/wskdeploy-test/helloworld
```