### PR TITLE
Validating wskdeploy with variety of manifest and deployment files

### DIFF
--- a/tests/src/integration/validate-manifest-deployment-file-extensions/actions/hello.js
+++ b/tests/src/integration/validate-manifest-deployment-file-extensions/actions/hello.js
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Return a simple greeting message for the whole world.
+ */
+function main(params) {
+    msg = "Hello, " + params.name + " from " + params.place;
+    console.log(msg)
+    return { payload:  msg };
+}
+

--- a/tests/src/integration/validate-manifest-deployment-file-extensions/deployment.yaml
+++ b/tests/src/integration/validate-manifest-deployment-file-extensions/deployment.yaml
@@ -1,0 +1,9 @@
+application:
+  name: IntegrationTest
+  packages:
+    ValidateYAMLExtension:
+      actions:
+        helloNodejs:
+          inputs:
+            name: Harvey
+            place: Houston

--- a/tests/src/integration/validate-manifest-deployment-file-extensions/deployment.yml
+++ b/tests/src/integration/validate-manifest-deployment-file-extensions/deployment.yml
@@ -1,0 +1,9 @@
+application:
+  name: IntegrationTest
+  packages:
+    ValidateYMLExtension:
+      actions:
+        helloNodejs:
+          inputs:
+            name: Irma
+            place: Florida

--- a/tests/src/integration/validate-manifest-deployment-file-extensions/manifest.yaml
+++ b/tests/src/integration/validate-manifest-deployment-file-extensions/manifest.yaml
@@ -1,0 +1,29 @@
+package:
+  name: ValidateYAMLExtension
+  actions:
+    # helloworld action in NodeJS
+    helloworld:
+      function: actions/hello.js
+      runtime: nodejs:6
+      inputs:
+        name:
+          type: string
+          description: name of a person
+        place:
+          type: string
+          description: location of a person
+      outputs:
+        payload:
+          type: string
+          description: a simple greeting message, Hello World!
+  triggers:
+    # trigger to activate helloworld action
+    trigger-for-valid-manifest-yaml:
+  rules:
+    # rule associating trigger with helloworld action
+    rule-for-valid-manifest-yaml:
+      trigger: trigger-for-valid-manifest-yaml
+      action: helloworld
+
+
+

--- a/tests/src/integration/validate-manifest-deployment-file-extensions/manifest.yml
+++ b/tests/src/integration/validate-manifest-deployment-file-extensions/manifest.yml
@@ -1,0 +1,29 @@
+package:
+  name: ValidateYMLExtension
+  actions:
+    # helloworld action in NodeJS
+    helloworld:
+      function: actions/hello.js
+      runtime: nodejs:6
+      inputs:
+        name:
+          type: string
+          description: name of a person
+        place:
+          type: string
+          description: location of a person
+      outputs:
+        payload:
+          type: string
+          description: a simple greeting message, Hello World!
+  triggers:
+    # trigger to activate helloworld action
+    trigger-for-valid-manifest-yml:
+  rules:
+    # rule associating trigger with helloworld action
+    rule-for-valid-manifest-yml:
+      trigger: trigger-for-valid-manifest-yml
+      action: helloworld
+
+
+

--- a/tests/src/integration/validate-manifest-deployment-file-extensions/not-standard-deployment.yaml
+++ b/tests/src/integration/validate-manifest-deployment-file-extensions/not-standard-deployment.yaml
@@ -1,0 +1,9 @@
+application:
+  name: IntegrationTest
+  packages:
+    ValidateNotStandardFileNames:
+      actions:
+        helloNodejs:
+          inputs:
+            name: Jose
+            place: Atlantic Ocean

--- a/tests/src/integration/validate-manifest-deployment-file-extensions/not-standard-manifest.yaml
+++ b/tests/src/integration/validate-manifest-deployment-file-extensions/not-standard-manifest.yaml
@@ -1,0 +1,29 @@
+package:
+  name: ValidateNotStandardFileNames
+  actions:
+    # helloworld action in NodeJS
+    helloworld:
+      function: actions/hello.js
+      runtime: nodejs:6
+      inputs:
+        name:
+          type: string
+          description: name of a person
+        place:
+          type: string
+          description: location of a person
+      outputs:
+        payload:
+          type: string
+          description: a simple greeting message, Hello World!
+  triggers:
+    # trigger to activate helloworld action
+    trigger-for-not-standard-file-names:
+  rules:
+    # rule associating trigger with helloworld action
+    rule-for-not-standard-file-names:
+      trigger: trigger-for-not-standard-file-names
+      action: helloworld
+
+
+

--- a/tests/src/integration/validate-manifest-deployment-file-extensions/random-name-1.yaml
+++ b/tests/src/integration/validate-manifest-deployment-file-extensions/random-name-1.yaml
@@ -1,0 +1,29 @@
+package:
+  name: ValidateRandomFileNames
+  actions:
+    # helloworld action in NodeJS
+    helloworld:
+      function: actions/hello.js
+      runtime: nodejs:6
+      inputs:
+        name:
+          type: string
+          description: name of a person
+        place:
+          type: string
+          description: location of a person
+      outputs:
+        payload:
+          type: string
+          description: a simple greeting message, Hello World!
+  triggers:
+    # trigger to activate helloworld action
+    trigger-for-random-file-names:
+  rules:
+    # rule associating trigger with helloworld action
+    rule-for-random-file-names:
+      trigger: trigger-for-random-file-names
+      action: helloworld
+
+
+

--- a/tests/src/integration/validate-manifest-deployment-file-extensions/random-name-2.yaml
+++ b/tests/src/integration/validate-manifest-deployment-file-extensions/random-name-2.yaml
@@ -1,0 +1,9 @@
+application:
+  name: IntegrationTest
+  packages:
+    ValidateRandomFileNames:
+      actions:
+        helloNodejs:
+          inputs:
+            name: Katia
+            place: Gulf of Mexico

--- a/tests/src/integration/validate-manifest-deployment-file-extensions/validate-file-extensions_test.go
+++ b/tests/src/integration/validate-manifest-deployment-file-extensions/validate-file-extensions_test.go
@@ -1,0 +1,90 @@
+// +build integration
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tests
+
+import (
+	"github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/common"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+var projectPath = "/src/github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/validate-manifest-deployment-file-extensions/"
+
+func TestYAMLExtension(t *testing.T) {
+	manifestPath   := os.Getenv("GOPATH") + projectPath + "manifest.yaml"
+	deploymentPath := os.Getenv("GOPATH") + projectPath + "deployment.yaml"
+	wskdeploy := common.NewWskdeploy()
+	_, err := wskdeploy.Deploy(manifestPath, deploymentPath)
+	assert.Equal(t, nil, err, "Failed to deploy based on the manifest and deployment files with .yaml extension.")
+	_, err = wskdeploy.Undeploy(manifestPath, deploymentPath)
+	assert.Equal(t, nil, err, "Failed to undeploy based on the manifest and deployment files with .yaml extension.")
+}
+
+func TestYMLExtension(t *testing.T) {
+	manifestPath   := os.Getenv("GOPATH") + projectPath + "manifest.yml"
+	deploymentPath := os.Getenv("GOPATH") + projectPath + "deployment.yml"
+	wskdeploy := common.NewWskdeploy()
+	_, err := wskdeploy.Deploy(manifestPath, deploymentPath)
+	assert.Equal(t, nil, err, "Failed to deploy based on the manifest and deployment files with .yml extension.")
+	_, err = wskdeploy.Undeploy(manifestPath, deploymentPath)
+	assert.Equal(t, nil, err, "Failed to undeploy based on the manifest and deployment files with .yml extension.")
+}
+
+func TestNonStandardFileNames(t *testing.T) {
+	manifestPath   := os.Getenv("GOPATH") + projectPath + "not-standard-manifest.yaml"
+	deploymentPath := os.Getenv("GOPATH") + projectPath + "not-standard-deployment.yaml"
+	wskdeploy := common.NewWskdeploy()
+	_, err := wskdeploy.Deploy(manifestPath, deploymentPath)
+	assert.Equal(t, nil, err, "Failed to deploy based on the manifest and deployment files with non standard names.")
+	_, err = wskdeploy.Undeploy(manifestPath, deploymentPath)
+	assert.Equal(t, nil, err, "Failed to undeploy based on the manifest and deployment files with non standard names.")
+}
+
+func TestRandomFileNames(t *testing.T) {
+	manifestPath   := os.Getenv("GOPATH") + projectPath + "random-name-1.yaml"
+	deploymentPath := os.Getenv("GOPATH") + projectPath + "random-name-2.yaml"
+	wskdeploy := common.NewWskdeploy()
+	_, err := wskdeploy.Deploy(manifestPath, deploymentPath)
+	assert.Equal(t, nil, err, "Failed to deploy based on the manifest and deployment files with random names.")
+	_, err = wskdeploy.Undeploy(manifestPath, deploymentPath)
+	assert.Equal(t, nil, err, "Failed to undeploy based on the manifest and deployment files with random names.")
+}
+
+func TestYAMLManifestWithYMLDeployment(t *testing.T) {
+	manifestPath   := os.Getenv("GOPATH") + projectPath + "yaml-manifest-with-yml-deployment.yaml"
+	deploymentPath := os.Getenv("GOPATH") + projectPath + "yml-deployment-with-yaml-manifest.yml"
+	wskdeploy := common.NewWskdeploy()
+	_, err := wskdeploy.Deploy(manifestPath, deploymentPath)
+	assert.Equal(t, nil, err, "Failed to deploy based on the manifest and deployment files with mix of .yaml and .yml extensions.")
+	_, err = wskdeploy.Undeploy(manifestPath, deploymentPath)
+	assert.Equal(t, nil, err, "Failed to undeploy based on the manifest and deployment files with mix of .yaml and .yml extension.")
+}
+
+func TestYMLManifestWithYAMLDeployment(t *testing.T) {
+	manifestPath   := os.Getenv("GOPATH") + projectPath + "yml-manifest-with-yaml-deployment.yml"
+	deploymentPath := os.Getenv("GOPATH") + projectPath + "yaml-deployment-with-yml-manifest.yaml"
+	wskdeploy := common.NewWskdeploy()
+	_, err := wskdeploy.Deploy(manifestPath, deploymentPath)
+	assert.Equal(t, nil, err, "Failed to deploy based on the manifest and deployment files with .yml manifest and .yaml deployment file.")
+	_, err = wskdeploy.Undeploy(manifestPath, deploymentPath)
+	assert.Equal(t, nil, err, "Failed to undeploy based on the manifest and deployment files with .yml manifest and .yaml deployment file.")
+}
+

--- a/tests/src/integration/validate-manifest-deployment-file-extensions/yaml-deployment-with-yml-manifest.yaml
+++ b/tests/src/integration/validate-manifest-deployment-file-extensions/yaml-deployment-with-yml-manifest.yaml
@@ -1,0 +1,9 @@
+application:
+  name: IntegrationTest
+  packages:
+    ValidateYMLManifestWithYAMLDeployment:
+      actions:
+        helloNodejs:
+          inputs:
+            name: Harvey
+            place: Houston

--- a/tests/src/integration/validate-manifest-deployment-file-extensions/yaml-manifest-with-yml-deployment.yaml
+++ b/tests/src/integration/validate-manifest-deployment-file-extensions/yaml-manifest-with-yml-deployment.yaml
@@ -1,0 +1,29 @@
+package:
+  name: ValidateYAMLManifestWithYMLDeployment
+  actions:
+    # helloworld action in NodeJS
+    helloworld:
+      function: actions/hello.js
+      runtime: nodejs:6
+      inputs:
+        name:
+          type: string
+          description: name of a person
+        place:
+          type: string
+          description: location of a person
+      outputs:
+        payload:
+          type: string
+          description: a simple greeting message, Hello World!
+  triggers:
+    # trigger to activate helloworld action
+    trigger-for-yaml-manifest-yml-deployment:
+  rules:
+    # rule associating trigger with helloworld action
+    rule-for-yaml-manifest-yml-deployment:
+      trigger: trigger-for-yaml-manifest-yml-deployment
+      action: helloworld
+
+
+

--- a/tests/src/integration/validate-manifest-deployment-file-extensions/yml-deployment-with-yaml-manifest.yml
+++ b/tests/src/integration/validate-manifest-deployment-file-extensions/yml-deployment-with-yaml-manifest.yml
@@ -1,0 +1,9 @@
+application:
+  name: IntegrationTest
+  packages:
+    ValidateYAMLManifestWithYMLDeployment:
+      actions:
+        helloNodejs:
+          inputs:
+            name: Harvey
+            place: Houston

--- a/tests/src/integration/validate-manifest-deployment-file-extensions/yml-manifest-with-yaml-deployment.yml
+++ b/tests/src/integration/validate-manifest-deployment-file-extensions/yml-manifest-with-yaml-deployment.yml
@@ -1,0 +1,29 @@
+package:
+  name: ValidateYMLManifestWithYAMLDeployment
+  actions:
+    # helloworld action in NodeJS
+    helloworld:
+      function: actions/hello.js
+      runtime: nodejs:6
+      inputs:
+        name:
+          type: string
+          description: name of a person
+        place:
+          type: string
+          description: location of a person
+      outputs:
+        payload:
+          type: string
+          description: a simple greeting message, Hello World!
+  triggers:
+    # trigger to activate helloworld action
+    trigger-for-yml-manifest-yaml-deployment:
+  rules:
+    # rule associating trigger with helloworld action
+    rule-for-yml-manifest-yaml-deployment:
+      trigger: trigger-for-yml-manifest-yaml-deployment
+      action: helloworld
+
+
+


### PR DESCRIPTION
Closes #381 

Added bunch of manifest and deployment files to test wskdeploy against:

```
 [182] -> ls -1 tests/src/integration/validate-manifest-deployment-file-extensions
actions/
deployment.yaml
deployment.yml
manifest.yaml
manifest.yml
not-standard-deployment.yaml
not-standard-manifest.yaml
random-name-1.yaml
random-name-2.yaml
validate-file-extensions_test.go
yaml-deployment-with-yml-manifest.yaml
yaml-manifest-with-yml-deployment.yaml
yml-deployment-with-yaml-manifest.yml
yml-manifest-with-yaml-deployment.yml
```