### PR TITLE
Use feed in trigger entity instead of source

### DIFF
--- a/parsers/manifest_parser.go
+++ b/parsers/manifest_parser.go
@@ -31,6 +31,7 @@ import (
 	"fmt"
 	"github.com/apache/incubator-openwhisk-client-go/whisk"
 	"github.com/apache/incubator-openwhisk-wskdeploy/utils"
+	"github.com/apache/incubator-openwhisk-wskdeploy/wski18n"
 	"gopkg.in/yaml.v2"
 )
 
@@ -384,12 +385,21 @@ func (dm *YAMLParser) ComposeTriggers(manifest *ManifestYAML) ([]*whisk.Trigger,
 		pub := false
 		wsktrigger.Publish = &pub
 
-		keyValArr := make(whisk.KeyValueArr, 0)
+		//print warning information when .Source is not empty
 		if trigger.Source != "" {
+			warningString := wski18n.T("WARNING: The 'source' YAML key in trigger entity is deprecated. Please use 'feed' instead as described in specifications.\n")
+			whisk.Debug(whisk.DbgWarn, warningString)
+		}
+		if trigger.Feed == "" {
+			trigger.Feed = trigger.Source
+		}
+
+		keyValArr := make(whisk.KeyValueArr, 0)
+		if trigger.Feed != "" {
 			var keyVal whisk.KeyValue
 
 			keyVal.Key = "feed"
-			keyVal.Value = trigger.Source
+			keyVal.Value = trigger.Feed
 
 			keyValArr = append(keyValArr, keyVal)
 

--- a/parsers/manifest_parser_test.go
+++ b/parsers/manifest_parser_test.go
@@ -956,7 +956,6 @@ func TestComposeSequences(t *testing.T) {
 }
 
 func TestComposeTriggers(t *testing.T) {
-//TODO 'source' should changed to 'feed' according to the spec after #450 is fixed.
 	data :=`package:
   name: helloworld
   triggers:
@@ -965,7 +964,7 @@ func TestComposeTriggers(t *testing.T) {
         name: string
         place: string
     trigger2:
-      source: myfeed
+      feed: myfeed
       inputs:
         name: myname
         place: myplace`

--- a/tests/usecases/alarmtrigger/manifest.yaml
+++ b/tests/usecases/alarmtrigger/manifest.yaml
@@ -17,7 +17,7 @@ package:
                     description: a simple greeting message, Hello World!
     triggers:
         Every12Hours:
-            source: /whisk.system/alarms/alarm
+            feed: /whisk.system/alarms/alarm
     rules:
         helloworldEvery12Hours:
             action: helloworld

--- a/tests/usecases/github/manifest.yaml
+++ b/tests/usecases/github/manifest.yaml
@@ -6,7 +6,7 @@ package:
             runtime: nodejs:6
     triggers:
         GitHubWebhookTrigger:
-            source: /whisk.system/github/webhook
+            feed: /whisk.system/github/webhook
     rules:
         rule-for-github-commits:
             action: print-github-commits

--- a/wski18n/resources/en_US.all.json
+++ b/wski18n/resources/en_US.all.json
@@ -205,6 +205,10 @@
   {
     "id": "Got error deleting package with error message: {{.err}} and error code: {{.code}}.\n",
     "translation": "Got error deleting package with error message: {{.err}} and error code: {{.code}}.\n"
+  },
+  {
+    "id": "WARNING: The 'source' YAML key in trigger entity is deprecated. Please use 'feed' instead as described in specifications.\n",
+    "translation": "WARNING: The 'source' YAML key in trigger entity is deprecated. Please use 'feed' instead as described in specifications.\n"
   }
 
 


### PR DESCRIPTION
Addressed issue #450 

In this PR, below updates are made:
- Change the code to support 'feed' in trigger entity; mark 'source' as deprecated.
- Print warning messages if 'source' is being used. 
```
WARNING: The 'source' YAML key in trigger entity will soon be deprecated. Please use 'feed' instead as described in specifications.
```
- Change the 'source' to 'feed' in the manifest files in test cases