### PR TITLE
Add line number and file name into ParseError

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,10 @@ ADD . /src/github.com/apache/incubator-openwhisk-wskdeploy
 RUN echo "Restoring Go dependencies"
 RUN cd /src/github.com/apache/incubator-openwhisk-wskdeploy && /bin/godep restore -v
 
+RUN echo "Patching gopkg.in/yaml.v2 to print the correct line numbers of YAML files"
+RUN cp /src/github.com/apache/incubator-openwhisk-wskdeploy/patch/Print-the-correct-line-numbers.patch /src/gopkg.in/yaml.v2/Print-the-correct-line-numbers.patch
+RUN cd /src/gopkg.in/yaml.v2 && git apply Print-the-correct-line-numbers.patch
+
 # All of the Go CLI binaries will be placed under a build folder
 RUN rm -rf /src/github.com/apache/incubator-openwhisk-wskdeploy/build
 RUN mkdir /src/github.com/apache/incubator-openwhisk-wskdeploy/build

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -162,7 +162,7 @@
 		},
 		{
 			"ImportPath": "gopkg.in/yaml.v2",
-			"Rev": "f8db564a0a4a5f6d04f66522493597f18e5ab4ae"
+			"Rev": "eb3733d160e74a9c7e442f435eb3bea458e1d19f"
 		},
         {
             "ImportPath": "github.com/palantir/stacktrace",

--- a/Makefile
+++ b/Makefile
@@ -9,15 +9,16 @@ BUILD=`git rev-parse HEAD`
 
 deps:
 	@echo "Installing dependencies"
+	rm -rf ${GOPATH}/src/gopkg.in/yaml.v2/
 	go get -d -t ./...
-
+	cp patch/Print-the-correct-line-numbers.patch ${GOPATH}/src/gopkg.in/yaml.v2/Print-the-correct-line-numbers.patch
+	cd ${GOPATH}/src/gopkg.in/yaml.v2; git apply Print-the-correct-line-numbers.patch
 
 LDFLAGS=-ldflags "-X main.Version=`date -u '+%Y-%m-%dT%H:%M:%S'` -X main.Build=`git rev-parse HEAD` "
 
 updatedeps:
 	@echo "Updating all dependencies"
 	@go get -d -u -f -fix -t ./...
-
 
 test: deps
 	@echo "Testing"

--- a/README.md
+++ b/README.md
@@ -55,6 +55,17 @@ $ cd $GOPATH
 $ go get github.com/apache/incubator-openwhisk-wskdeploy  # see known issues below if you get an error
 ```
 
+Patch gopkg.in/yaml.v2 in order to work properly. The package yaml.v2 is used to parse the files in YAML format. As we
+discover an valid issue reported on [this page](https://github.com/go-yaml/yaml/issues/280), we provide a patch to fix it under the folder of patch in the HOME
+directory of this project. Please run the commands as below to patch gopkg.in/yaml.v2:
+
+```sh
+$ cd src/github.com/apache/incubator-openwhisk-wskdeploy/
+$ cp patch/Print-the-correct-line-numbers.patch $GOPATH/src/gopkg.in/yaml.v2/
+$ cd $GOPATH/src/gopkg.in/yaml.v2
+$ git apply Print-the-correct-line-numbers.patch
+```
+
 And finally build `wskdeploy`
 
 ```sh

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -193,10 +193,6 @@ func Deploy() error {
 		deployer.ProjectPath = projectPath
 		deployer.ManifestPath = utils.Flags.ManifestPath
 		deployer.DeploymentPath = utils.Flags.DeploymentPath
-		// perform some quick check here.
-		go func() {
-			deployer.Check()
-		}()
 		deployer.IsDefault = utils.Flags.UseDefaults
 
 		deployer.IsInteractive = utils.Flags.UseInteractive

--- a/deployers/manifestreader.go
+++ b/deployers/manifestreader.go
@@ -53,7 +53,7 @@ func (deployer *ManifestReader) ParseManifest() (*parsers.ManifestYAML, *parsers
 }
 
 func (reader *ManifestReader) InitRootPackage(manifestParser *parsers.YAMLParser, manifest *parsers.ManifestYAML) error {
-	packg, err := manifestParser.ComposePackage(manifest)
+	packg, err := manifestParser.ComposePackage(manifest, reader.serviceDeployer.ManifestPath)
 	if err != nil {
         return utils.NewInputYamlFormatError(err.Error())
     }
@@ -66,7 +66,7 @@ func (reader *ManifestReader) InitRootPackage(manifestParser *parsers.YAMLParser
 func (deployer *ManifestReader) HandleYaml(sdeployer *ServiceDeployer, manifestParser *parsers.YAMLParser, manifest *parsers.ManifestYAML) error {
 
     var err error
-	deps, err := manifestParser.ComposeDependencies(manifest, deployer.serviceDeployer.ProjectPath)
+	deps, err := manifestParser.ComposeDependencies(manifest, deployer.serviceDeployer.ProjectPath, deployer.serviceDeployer.ManifestPath)
     if err != nil {
         return utils.NewInputYamlFormatError(err.Error())
     }
@@ -81,7 +81,7 @@ func (deployer *ManifestReader) HandleYaml(sdeployer *ServiceDeployer, manifestP
         return utils.NewInputYamlFormatError(err.Error())
     }
 
-	triggers, err := manifestParser.ComposeTriggers(manifest)
+	triggers, err := manifestParser.ComposeTriggers(manifest, deployer.serviceDeployer.ManifestPath)
     if err != nil {
         return utils.NewInputYamlFormatError(err.Error())
     }

--- a/parsers/deploy_parser.go
+++ b/parsers/deploy_parser.go
@@ -41,17 +41,19 @@ func (dm *YAMLParser) MarshalDeployment(deployment *DeploymentYAML) (output []by
 	return data, nil
 }
 
-func (dm *YAMLParser) ParseDeployment(dply string) (*DeploymentYAML, error) {
+func (dm *YAMLParser) ParseDeployment(deploymentPath string) (*DeploymentYAML, error) {
 	dplyyaml := DeploymentYAML{}
-	content, err := new(utils.ContentReader).LocalReader.ReadLocal(dply)
+	content, err := new(utils.ContentReader).LocalReader.ReadLocal(deploymentPath)
     if err != nil {
         return &dplyyaml, utils.NewInputYamlFileError(err.Error())
     }
 	err = dm.UnmarshalDeployment(content, &dplyyaml)
     if err != nil {
-        return &dplyyaml, utils.NewInputYamlFileError(err.Error())
+        if err != nil {
+            return &dplyyaml, utils.NewParserErr(deploymentPath, err.Error())
+        }
     }
-	dplyyaml.Filepath = dply
+	dplyyaml.Filepath = deploymentPath
 	return &dplyyaml, nil
 }
 

--- a/parsers/deploy_parser_test.go
+++ b/parsers/deploy_parser_test.go
@@ -1,0 +1,63 @@
+// +build unit
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package parsers
+
+import (
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+func TestInvalidDeploymentYaml(t *testing.T) {
+    data :=`application:
+  invalidKey: test
+  name: wskdeploy-samples`
+    tmpfile, err := _createTmpfile(data, "deployment_parser_test_")
+    if err != nil {
+        assert.Fail(t, "Failed to create temp file")
+    }
+    defer func() {
+        tmpfile.Close()
+        os.Remove(tmpfile.Name())
+    }()
+    p := NewYAMLParser()
+    _, err = p.ParseDeployment(tmpfile.Name())
+    assert.NotNil(t, err)
+    assert.Contains(t, err.Error(), "line 2: field invalidKey not found in struct parsers.Application")
+}
+
+func TestMappingValueDeploymentYaml(t *testing.T) {
+    data :=`application:
+  name: wskdeploy-samples
+    packages: test`
+    tmpfile, err := _createTmpfile(data, "deployment_parser_test_")
+    if err != nil {
+        assert.Fail(t, "Failed to create temp file")
+    }
+    defer func() {
+        tmpfile.Close()
+        os.Remove(tmpfile.Name())
+    }()
+    p := NewYAMLParser()
+    _, err = p.ParseDeployment(tmpfile.Name())
+    assert.NotNil(t, err)
+    // go-yaml/yaml prints the wrong line number for mapping values. It should be 3.
+    assert.Contains(t, err.Error(), "line 2: mapping values are not allowed in this context")
+}

--- a/patch/Print-the-correct-line-numbers.patch
+++ b/patch/Print-the-correct-line-numbers.patch
@@ -1,0 +1,39 @@
+From 1427c481ac7a92dee2b805712da66c0f6cff4948 Mon Sep 17 00:00:00 2001
+From: Vincent Hou <shou@us.ibm.com>
+Date: Mon, 11 Sep 2017 11:35:58 -0400
+Subject: [PATCH] Print the correct line numbers
+
+---
+ decode.go      | 2 +-
+ decode_test.go | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/decode.go b/decode.go
+index db1f5f2..0052344 100644
+--- a/decode.go
++++ b/decode.go
+@@ -641,7 +641,7 @@ func (d *decoder) mappingStruct(n *node, out reflect.Value) (good bool) {
+ 			d.unmarshal(n.children[i+1], value)
+ 			inlineMap.SetMapIndex(name, value)
+ 		} else if d.strict {
+-			d.terrors = append(d.terrors, fmt.Sprintf("line %d: field %s not found in struct %s", n.line+1, name.String(), out.Type()))
++			d.terrors = append(d.terrors, fmt.Sprintf("line %d: field %s not found in struct %s", ni.line+1, name.String(), out.Type()))
+ 		}
+ 	}
+ 	return true
+diff --git a/decode_test.go b/decode_test.go
+index 713b1ee..831a808 100644
+--- a/decode_test.go
++++ b/decode_test.go
+@@ -984,7 +984,7 @@ func (s *S) TestUnmarshalStrict(c *C) {
+ 	err = yaml.Unmarshal([]byte("a: 1\nb: 2\nc: 3"), &v)
+ 	c.Check(err, IsNil)
+ 	err = yaml.UnmarshalStrict([]byte("a: 1\nb: 2\nc: 3"), &v)
+-	c.Check(err, ErrorMatches, "yaml: unmarshal errors:\n  line 1: field c not found in struct struct { A int; B int }")
++	c.Check(err, ErrorMatches, "yaml: unmarshal errors:\n  line 3: field c not found in struct struct { A int; B int }")
+ }
+ 
+ //var data []byte
+-- 
+2.8.2
+

--- a/tests/src/integration/triggerrule/manifest.yml
+++ b/tests/src/integration/triggerrule/manifest.yml
@@ -20,4 +20,3 @@ package:
       #the action name and the action file greeting.js should consistent.
       #currently the implementation decide the action name consistent with action file name?
       action: greeting
-

--- a/utils/contentreader.go
+++ b/utils/contentreader.go
@@ -34,10 +34,15 @@ type URLReader struct {
 
 func (urlReader *URLReader) ReadUrl(url string) (content []byte, err error) {
 	resp, err := http.Get(url)
-	Check(err)
+	if err != nil {
+        return content, err
+    }
 	b, err := ioutil.ReadAll(resp.Body)
-	defer resp.Body.Close()
-	Check(err)
+    if err != nil {
+        return content, err
+    } else {
+        defer resp.Body.Close()
+    }
 	return b, nil
 }
 

--- a/utils/fileoperations.go
+++ b/utils/fileoperations.go
@@ -49,12 +49,16 @@ func FileExists(file string) bool {
 
 func IsDirectory(filePath string) bool {
 	f, err := os.Open(filePath)
-	Check(err)
-
-	defer f.Close()
+	if err != nil {
+        return false
+    } else {
+        defer f.Close()
+    }
 
 	fi, err := f.Stat()
-	Check(err)
+    if err != nil {
+        return false
+    }
 
 	switch mode := fi.Mode(); {
 	case mode.IsDir():
@@ -102,9 +106,11 @@ func CreateActionFromFile(manipath, filePath string) (*whisk.Action, error) {
 			dat, err = new(ContentReader).URLReader.ReadUrl(filePath)
 		}
 
+        if err != nil {
+            return action, err
+        }
 		code := string(dat)
 		pub := false
-		Check(err)
 		action.Exec = new(whisk.Exec)
 		action.Exec.Code = &code
 		action.Exec.Kind = kind
@@ -161,26 +167,24 @@ func WriteProps(path string, props map[string]string) error {
 
 	for k, v := range props {
 		_, err := file.WriteString(k)
-		Check(err)
+        if err != nil {
+            return err
+        }
 
 		_, err = file.WriteString("=")
-		Check(err)
+        if err != nil {
+            return err
+        }
 
 		_, err = file.WriteString(v)
-		Check(err)
+        if err != nil {
+            return err
+        }
 
 		_, err = file.WriteString("\n")
-		Check(err)
+        if err != nil {
+            return err
+        }
 	}
 	return nil
-}
-
-// Load configuration will load properties from a file
-func LoadConfiguration(propPath string) ([]string, error) {
-	props, err := ReadProps(propPath)
-	Check(err)
-	Namespace := props["NAMESPACE"]
-	Apihost := props["APIHOST"]
-	Authtoken := props["AUTH"]
-	return []string{Namespace, Apihost, Authtoken}, nil
 }

--- a/utils/gitreader.go
+++ b/utils/gitreader.go
@@ -55,18 +55,26 @@ func (reader *GitReader) CloneDependency() error {
 
 	os.MkdirAll(reader.ProjectPath, os.ModePerm)
 	output, err := os.Create(path.Join(reader.ProjectPath, zipFileName))
-	Check(err)
+	if err != nil {
+        return err
+    }
 	defer output.Close()
 
 	response, err := http.Get(zipFilePath)
-	Check(err)
+    if err != nil {
+        return err
+    }
 	defer response.Body.Close()
 
 	_, err = io.Copy(output, response.Body)
-	Check(err)
+    if err != nil {
+        return err
+    }
 
 	zipReader, err := zip.OpenReader(path.Join(reader.ProjectPath, zipFileName))
-	Check(err)
+    if err != nil {
+        return err
+    }
 
 	u, err := url.Parse(reader.Url)
 	team, _ := path.Split(u.Path)
@@ -83,11 +91,15 @@ func (reader *GitReader) CloneDependency() error {
 		}
 
 		fileReader, err := file.Open()
-		Check(err)
+        if err != nil {
+            return err
+        }
 		defer fileReader.Close()
 
 		targetFile, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, file.Mode())
-		Check(err)
+        if err != nil {
+            return err
+        }
 		defer targetFile.Close()
 
 		if _, err := io.Copy(targetFile, fileReader); err != nil {

--- a/utils/misc.go
+++ b/utils/misc.go
@@ -81,7 +81,9 @@ func GetURLBase(host string) (*url.URL, error) {
 
 func GetHomeDirectory() string {
 	usr, err := user.Current()
-	Check(err)
+	if err != nil {
+        return ""
+    }
 
 	return usr.HomeDir
 }
@@ -113,11 +115,13 @@ func IsJSON(s string) (interface{}, bool) {
 
 }
 
-func PrettyJSON(j interface{}) string {
+func PrettyJSON(j interface{}) (string, error) {
 	formatter := prettyjson.NewFormatter()
 	bytes, err := formatter.Marshal(j)
-	Check(err)
-	return string(bytes)
+	if err != nil {
+        return "", err
+    }
+	return string(bytes), nil
 }
 
 // Common utilities
@@ -248,7 +252,9 @@ func GetExec(artifact string, kind string, isDocker bool, mainEntry string) (*wh
 
 	if !isDocker || ext == ".zip" {
 		content, err = new(ContentReader).ReadLocal(artifact)
-		Check(err)
+		if err != nil {
+            return nil, err
+        }
 		code = string(content)
 		exec.Code = &code
 	}

--- a/utils/util_test.go
+++ b/utils/util_test.go
@@ -31,8 +31,7 @@ var contentReader = new(ContentReader)
 var testfile = "../tests/dat/deployment.yaml"
 
 func TestLocalReader_ReadLocal(t *testing.T) {
-	b, err := contentReader.ReadLocal(testfile)
-	Check(err)
+	b, _ := contentReader.ReadLocal(testfile)
 	if b == nil {
 		t.Error("get local centent failed")
 	}
@@ -40,8 +39,7 @@ func TestLocalReader_ReadLocal(t *testing.T) {
 
 func TestURLReader_ReadUrl(t *testing.T) {
 	var exampleUrl = "http://www.baidu.com"
-	b, err := contentReader.ReadUrl(exampleUrl)
-	Check(err)
+	b, _ := contentReader.ReadUrl(exampleUrl)
 	if b == nil {
 		t.Error("get web content failed")
 	}

--- a/utils/wskdeployerror.go
+++ b/utils/wskdeployerror.go
@@ -50,7 +50,7 @@ type BaseErr struct {
 }
 
 func (e *BaseErr) Error() string {
-    return fmt.Sprintf("%s [%d]: %s", e.FileName, e.LineNum, e.Message)
+    return fmt.Sprintf("%s [%d]: %s\n", e.FileName, e.LineNum, e.Message)
 }
 
 func (e *BaseErr) SetFileName(fileName string) {
@@ -86,7 +86,7 @@ func (e *InputYamlFileError) SetErrorType(errorType string) {
 }
 
 func (e *InputYamlFileError) Error() string {
-    return fmt.Sprintf("%s [%d]: %s =====> %s", e.FileName, e.LineNum, e.errorType, e.Message)
+    return fmt.Sprintf("%s [%d]: %s =====> %s\n", e.FileName, e.LineNum, e.errorType, e.Message)
 }
 
 type InputYamlFormatError struct {
@@ -122,7 +122,7 @@ func NewWhiskClientError(errMessage string, code int) *WhiskClientError {
 }
 
 func (e *WhiskClientError) Error() string {
-    return fmt.Sprintf("%s [%d]: %s =====> %s Error code: %d.", e.FileName, e.LineNum, e.errorType, e.Message, e.errorCode)
+    return fmt.Sprintf("%s [%d]: %s =====> %s Error code: %d.\n", e.FileName, e.LineNum, e.errorType, e.Message, e.errorCode)
 }
 
 type InvalidWskpropsError struct {
@@ -140,13 +140,20 @@ func NewInvalidWskpropsError(errMessage string) *InvalidWskpropsError {
 
 type ParserErr struct {
     BaseErr
+    YamlFile string
 }
 
-func NewParserErr(msg string) *ParserErr {
+func NewParserErr(yamlFile string, msg string) *ParserErr {
     _, fn, line, _ := runtime.Caller(1)
-    var err = &ParserErr{}
+    var err = &ParserErr{
+        YamlFile: yamlFile,
+    }
     err.SetFileName(fn)
     err.SetLineNum(line)
     err.SetMessage(msg)
     return err
+}
+
+func (e *ParserErr) Error() string {
+    return fmt.Sprintf("%s [%d]: Failed to parse the yaml file %s =====> %s\n", e.FileName, e.LineNum, e.YamlFile, e.Message)
 }

--- a/wski18n/resources/en_US.all.json
+++ b/wski18n/resources/en_US.all.json
@@ -205,7 +205,9 @@
   {
     "id": "Got error deleting package with error message: {{.err}} and error code: {{.code}}.\n",
     "translation": "Got error deleting package with error message: {{.err}} and error code: {{.code}}.\n"
+  },
+  {
+    "id": "Got error deleting binding package with error message: {{.err}} and error code: {{.code}}.\n",
+    "translation": "Got error deleting binding package with error message: {{.err}} and error code: {{.code}}.\n"
   }
-
-
 ]


### PR DESCRIPTION
The information of the line numbers are available in err.Error(),
and the file name is saved in the varible YamlFile.