### PR TITLE
add cloudant case in integration test

### DIFF
--- a/tests/src/integration/cloudant/actions/process-change.js
+++ b/tests/src/integration/cloudant/actions/process-change.js
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Print the document to console which has changes
+ *
+ * @param document which has changes
+ */
+
+function main(params) {
+      var message = "The changed document ID is:"+params._id;
+      console.log(message);
+      return {change: message}
+}

--- a/tests/src/integration/cloudant/cloudant_test.go
+++ b/tests/src/integration/cloudant/cloudant_test.go
@@ -1,0 +1,51 @@
+// +build integration
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tests
+
+import (
+	"testing"
+	"github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/common"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"fmt"
+)
+
+var wskprops = common.GetWskprops()
+
+func TestCloudant(t *testing.T) {
+	wskprops := common.GetWskpropsFromEnvVars(common.BLUEMIX_APIHOST, common.BLUEMIX_NAMESPACE, common.BLUEMIX_AUTH)
+	err := common.ValidateWskprops(wskprops)
+	if err != nil {
+		fmt.Println(err.Error())
+		fmt.Println("Wsk properties are not properly configured, so tests are skipped.")
+	} else {
+		wskdeploy := common.NewWskdeploy()
+		_, err := wskdeploy.DeployWithCredentials(manifestPath, deploymentPath, wskprops)
+		assert.Equal(t, nil, err, "Failed to deploy the manifest file.")
+		_, err = wskdeploy.UndeployWithCredentials(manifestPath, deploymentPath, wskprops)
+		assert.Equal(t, nil, err, "Failed to undeploy the manifest file.")
+	}
+}
+
+var (
+	manifestPath = os.Getenv("GOPATH") + "/src/github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/cloudant/manifest.yml"
+	deploymentPath = ""
+)
+

--- a/tests/src/integration/cloudant/manifest.yaml
+++ b/tests/src/integration/cloudant/manifest.yaml
@@ -1,0 +1,38 @@
+# This manifest file reads following env. variables:
+#   CLOUDANT_USERNAME
+#   CLOUDANT_PASSWORD
+
+package:
+    name: cloudant-sample
+    dependencies:
+        # binding cloudant package named openwhisk-cloudant
+        openwhisk-cloudant:
+            location: /whisk.system/cloudant
+            inputs:
+                username: $CLOUDANT_USERNAME
+                password: $CLOUDANT_PASSWORD
+                host: ${CLOUDANT_USERNAME}.cloudant.com
+    triggers:
+        # Trigger named "data-inserted-trigger"
+        # Creating trigger to fire events when data is inserted into database
+        data-inserted-trigger:
+            source: openwhisk-cloudant/changes
+            inputs:
+                dbname: testdb
+    actions:
+        # Action named "process-change"
+        # Creating action that is printing data which is written to the database
+        process-change:
+            location: actions/process-change.js
+
+    sequences:
+        # Sequence named "process-change-cloudant-sequence"
+        # Creating sequence to connect the cloudant "read" action with the "process-change" action
+        process-change-cloudant-sequence:
+            actions: openwhisk-cloudant/read, process-change
+    rules:
+        # Rule named "log-change-rule"
+        # Creating rule that maps database change trigger to sequence
+        log-change-rule:
+            trigger: data-inserted-trigger
+            action: process-change-cloudant-sequence


### PR DESCRIPTION
Close #473 

This integration test case will deploy follow items to OpenWhisk:
```
Entities in namespace: <namespace>
packages
/<namespace>/openwhisk-cloudant                            private
/<namespace>/cloudant-sample                               private
actions
/<namespace>/cloudant-sample/process-change-cloudant-sequence private sequence
/<namespace>/cloudant-sample/process-change                private nodejs:6
triggers
/<namespace>/data-inserted-trigger                         private
rules
/<namespace>/log-change-rule                               private
```