### PR TITLE
Support string and env variable concatenation

### DIFF
--- a/utils/misc.go
+++ b/utils/misc.go
@@ -121,9 +121,16 @@ func Ask(reader *bufio.Reader, question string, def string) string {
 // Test if a string
 func isValidEnvironmentVar(value string) bool {
 
-	// A valid Env. variable should start with '$' (dollar) char.
-	// AND have at least 1 additional character after it.
-	if value != "" && len(value) > 1 && strings.HasPrefix(value, "$") {
+	// A valid Env. variable should start with or contain '$' (dollar) char.
+	//
+	// If the value is a single Env. variable, it should start with a '$' (dollar) char
+	// and have at least 1 additional character after it, e.g. $ENV_VAR
+	// If the value is a concatenation of a string and a Env. variable, it should contain '$' (dollar)
+	// and have a string following which is surrounded with '{' and '}', e.g. xxx${ENV_VAR}xxx.
+	if value != "" && strings.HasPrefix(value, "$") && len(value) > 1  {
+		return true
+	}
+	if value != "" && strings.Contains(value,"${") && strings.Count(value,"{")==strings.Count(value,"}") {
 		return true
 	}
 	return false
@@ -138,20 +145,38 @@ func GetEnvVar(key interface{}) interface{} {
 	}
 
 	if reflect.TypeOf(key).String() == "string" {
-		if isValidEnvironmentVar(key.(string)) {
+		keystr := key.(string)
+		if isValidEnvironmentVar(keystr) {
 			// retrieve the value of the env. var. from the host system.
-			envkey := strings.Split(key.(string), "$")[1]
-			value := os.Getenv(envkey)
-			if value == "" {
-				// Issue a warning to the user (verbose) that env. var. was not found
-				// (i.e., and empty string was returned).
-				fmt.Println("WARNING: Missing Environment Variable " + envkey + ".")
+			var thisValue string
+			//split the string with ${}
+			//test if the substr is a environment var
+			//if it is, replace it with the value
+			f := func(c rune) bool {
+				return c=='$' || c=='{' || c=='}'
 			}
-			return value
+			for _,substr := range strings.FieldsFunc(keystr, f) {
+				//if the substr is a $ENV_VAR
+				if strings.Contains(keystr,"$"+substr) {
+					thisValue = os.Getenv(substr)
+					if thisValue == "" {
+						fmt.Println("WARNING: Missing Environment Variable " + substr + ".")
+					}
+					keystr = strings.Replace(keystr,"$"+substr,thisValue,-1)
+				//if the substr is a ${ENV_VAR}
+				} else if strings.Contains(keystr,"${"+substr+"}") {
+					thisValue = os.Getenv(substr)
+					if thisValue == "" {
+						fmt.Println("WARNING: Missing Environment Variable " + substr + ".")
+					}
+					keystr = strings.Replace(keystr,"${"+substr+"}",thisValue,-1)
+				}
+			}
+			return keystr
 		}
 
 		// The key was not a valid env. variable, simply return it as the value itself (of type string)
-		return key.(string)
+		return keystr
 	}
 	return key
 }

--- a/utils/util_test.go
+++ b/utils/util_test.go
@@ -57,6 +57,13 @@ func TestGetEnvVar(t *testing.T) {
 	assert.Equal(t, "oh, dollars!", GetEnvVar("$WithDollar"), "dollar sign should be handled.")
 	assert.Equal(t, "5000", GetEnvVar("5000"), "Should be no difference between integer and string.")
 	assert.Equal(t, "", GetEnvVar("$WithDollarAgain"), "if not found in environemnt, return empty string.")
+	assert.Equal(t, "oh, dollars!.ccc.aaa", GetEnvVar("${WithDollar}.ccc.aaa"), "String concatenation fail")
+	assert.Equal(t, "ddd.NO dollar.aaa", GetEnvVar("ddd.${NoDollar}.aaa"), "String concatenation fail")
+	assert.Equal(t, "oh, dollars!.NO dollar.aaa", GetEnvVar("${WithDollar}.${NoDollar}.aaa"), "String concatenation fail")
+	assert.Equal(t, "ddd.ccc.oh, dollars!", GetEnvVar("ddd.ccc.${WithDollar}"), "String concatenation fail")
+	assert.Equal(t, "", GetEnvVar("$WithDollarAgain.ccc.aaa"), "String concatenation fail")
+	assert.Equal(t, "ddd..aaa", GetEnvVar("ddd.${WithDollarAgain}.aaa"), "String concatenation fail")
+	assert.Equal(t, "oh, dollars!NO dollar.NO dollar", GetEnvVar("${WithDollar}${NoDollar}.${NoDollar}"), "String concatenation fail")
 }
 
 func TestDependencies(t *testing.T) {


### PR DESCRIPTION
Close #501 

After this PR, we can support below format of values:
- $ENV_VAR
- ${ENV_VAR}
- yyyy${ENV_VAR}xxxx
- yyyy${ENV_VAR1}xxxx${ENV_VAR2}zzzz