### PR TITLE
Updated .PHONY targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,4 +47,4 @@ install:
 clean:
 	if [ -f ${BINARY} ] ; then rm ${BINARY}; fi
 
-.PHONY: clean install
+.PHONY: clean install build deps updatedeps format lint test integration_test


### PR DESCRIPTION
All targets that do not represent file names should be phony targets