### PR TITLE
Check mandatory field Version and License

### DIFF
--- a/parsers/manifest_parser.go
+++ b/parsers/manifest_parser.go
@@ -216,6 +216,31 @@ func (dm *YAMLParser) ComposePackage(pkg Package, packageName string, filePath s
 	pub := false
 	pag.Publish = &pub
 
+	//Version is a mandatory value
+	//If it is an empty string, it will be set to default value
+	//And print an warning message
+	if pkg.Version == "" {
+		warningString := wski18n.T("WARNING: Mandatory field Package Version must be set.\n")
+		whisk.Debug(whisk.DbgWarn, warningString)
+		warningString = wski18n.T("WARNING: Package Version is not saved in the current wskdeploy version.\n")
+		whisk.Debug(whisk.DbgWarn, warningString)
+		pkg.Version = "0.0.1"
+	}
+
+	//License is a mandatory value
+	//set license to unknown if it is an empty string
+	//And print an warning message
+	if pkg.License == "" {
+		warningString := wski18n.T("WARNING: Mandatory field Package License must be set.\n")
+		whisk.Debug(whisk.DbgWarn, warningString)
+		warningString = wski18n.T("WARNING: Package License is not saved in the current wskdeploy version.\n")
+		whisk.Debug(whisk.DbgWarn, warningString)
+		pkg.License = "unlicensed"
+	} else {
+		utils.CheckLicense(pkg.License)
+	}
+
+	//set parameters
 	keyValArr := make(whisk.KeyValueArr, 0)
 	for name, param := range pkg.Inputs {
 		var keyVal whisk.KeyValue

--- a/parsers/yamlparser.go
+++ b/parsers/yamlparser.go
@@ -136,8 +136,8 @@ type Package struct {
 	//mapping to wsk.SentPackageNoPublish.Name
 	Packagename string `yaml:"name"` //used in manifest.yaml
 	//mapping to wsk.SentPackageNoPublish.Version
-	Version      string                `yaml:"version"` //used in manifest.yaml
-	License      string                `yaml:"license"` //used in manifest.yaml
+	Version      string                `yaml:"version"` //used in manifest.yaml, mandatory
+	License      string                `yaml:"license"` //used in manifest.yaml, mandatory
 	Repositories []Repository          `yaml:"repositories,omitempty"`
 	Dependencies map[string]Dependency `yaml: dependencies` //used in manifest.yaml
 	Function     string                `yaml:"function"`    //used in deployment.yaml

--- a/utils/validation.go
+++ b/utils/validation.go
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// qualifiedname.go
+package utils
+
+import (
+	"encoding/json"
+	"github.com/apache/incubator-openwhisk-client-go/whisk"
+	"github.com/apache/incubator-openwhisk-wskdeploy/wski18n"
+	"strings"
+)
+
+var LocalLicenseRecords = map[string][]string{
+	"APACHE": {"1.0", "1.1", "2.0"},
+	"LGPL":   {"2.0", "2.1", "3.0"},
+	"GPL":    {"1.0", "2.0", "3.0"},
+	"MPL":    {"1.0", "1.1", "2.0", "2.0-no-copyleft-exception"},
+	"BSD":    {"2-Clause", "2-Clause-FreeBSD", "2-Clause-NetBSD", "3-Clause", "3-Clause-Clear", "3-Clause-No-Nuclear-License", "3-Clause-No-Nuclear-License-2014", "3-Clause-No-Nuclear-Warranty", "3-Clause-Attribution", "4-Clause", "Protection", "Source-Code", "4-Clause-UC", "3-Clause-LBNL"},
+	"0BSD":   {""},
+	"GFDL":   {"1.0", "1.2", "1.3"},
+	"AGPL":   {"3.0"},
+	"MIT":    {"", "feh", "enna", "advertising", "CMU"},
+	"AFL":    {"1.1", "1.2", "2.0", "2.1", "3.0"},
+	"APSL":   {"1.0", "1.1", "1.2", "2.0"},
+	"EPL":    {"1.0"},
+	"OSL":    {"1.0", "1.1", "2.0", "2.1", "3.0"},
+	"PHP":    {"3.0", "3.01"},
+}
+
+var RemoteLicenseURL = "https://raw.githubusercontent.com/spdx/license-list-data/master/json/licenses.json"
+
+type LicenseJSON struct {
+	Description string        `json:"licenseListVersion"`
+	Licenses    []LicenseItem `json:"licenses"`
+	ReleaseDate string        `json:"releaseDate"`
+}
+
+type LicenseItem struct {
+	Name      string `json:"name"`
+	LicenseID string `json:"licenseId"`
+}
+
+var license_json = LicenseJSON{}
+
+//Check if the license is valid
+//Check local data record at first
+//Then check remote json data
+func CheckLicense(license string) bool {
+	if !LicenseLocalValidation(license) && !LicenseRemoteValidation(license) {
+		warningString := wski18n.T("WARNING: License {{.licenseID}} is not a valid one.\n",
+			map[string]interface{}{"licenseID": license})
+		whisk.Debug(whisk.DbgWarn, warningString)
+		return false
+	}
+	return true
+}
+
+// Check if the license is in local license record
+// If it is, return ture
+// If it is not, return false
+func LicenseLocalValidation(license string) bool {
+	license_upper := strings.ToUpper(license) //change it to upper case
+	parts := strings.SplitN(license_upper, "-", 2)
+	license_type := parts[0]
+	license_version := ""
+	if len(parts) > 1 {
+		license_version = parts[1]
+	}
+
+	version_list := LocalLicenseRecords[license_type]
+	if version_list == nil {
+		return false
+	} else {
+		for _, version := range LocalLicenseRecords[license_type] {
+			if license_version == strings.ToUpper(version) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+//Check if license is one of validate license in
+//https://github.com/spdx/license-list-data/blob/master/json/licenses.json
+// If it is, return ture
+// If it is not, return false
+func LicenseRemoteValidation(license string) bool {
+	license_upper := strings.ToUpper(license) //change it to upper case
+
+	if len(license_json.Licenses) == 0 {
+		json_data, err := Read(RemoteLicenseURL)
+		if err != nil {
+			errString := wski18n.T("Failed to get the remote license json.\n")
+			whisk.Debug(whisk.DbgError, errString)
+			return false
+		}
+
+		//parse json
+		err = json.Unmarshal(json_data, &license_json)
+		if err != nil || len(license_json.Licenses) == 0 {
+			errString := wski18n.T("Failed to parse the remote license json.\n")
+			whisk.Debug(whisk.DbgError, errString)
+			return false
+		}
+	}
+
+	//check license
+	for _, licenseobj := range license_json.Licenses {
+		if strings.ToUpper(licenseobj.LicenseID) == license_upper {
+			return true
+		}
+	}
+	return false
+}

--- a/utils/validation_test.go
+++ b/utils/validation_test.go
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// qualifiedname.go
+package utils
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestLicenseLocalValidation(t *testing.T) {
+	assert.False(t, LicenseLocalValidation("---"))
+	assert.True(t, LicenseLocalValidation("Apache-2.0"))
+	assert.True(t, LicenseLocalValidation("0BSD"))
+	assert.True(t, LicenseLocalValidation("0bsd"))
+	assert.True(t, LicenseLocalValidation("MIT"))
+	assert.True(t, LicenseLocalValidation("MIT-feh"))
+	assert.True(t, LicenseLocalValidation("BSD-3-Clause-LBNL"))
+	assert.False(t, LicenseLocalValidation("GPL-3.0+"))
+	assert.False(t, LicenseLocalValidation("Zimbra-1.3"))
+	assert.False(t, LicenseLocalValidation("xpp"))
+}
+
+func TestLicenseRemoteValidation(t *testing.T) {
+	assert.False(t, LicenseRemoteValidation("---"))
+	assert.True(t, LicenseRemoteValidation("Apache-2.0"))
+	assert.True(t, LicenseRemoteValidation("0BSD"))
+	assert.True(t, LicenseRemoteValidation("0bsd"))
+	assert.True(t, LicenseRemoteValidation("MIT"))
+	assert.True(t, LicenseRemoteValidation("MIT-feh"))
+	assert.True(t, LicenseRemoteValidation("BSD-3-Clause-LBNL"))
+	assert.True(t, LicenseRemoteValidation("GPL-3.0+"))
+	assert.True(t, LicenseRemoteValidation("Zimbra-1.3"))
+	assert.True(t, LicenseRemoteValidation("xpp"))
+}
+
+func TestCheckLicense(t *testing.T) {
+	assert.False(t, CheckLicense("---"))
+	assert.True(t, CheckLicense("Apache-2.0"))
+	assert.True(t, CheckLicense("0BSD"))
+	assert.True(t, CheckLicense("0bsd"))
+	assert.True(t, CheckLicense("MIT"))
+	assert.True(t, CheckLicense("MIT-feh"))
+	assert.True(t, CheckLicense("BSD-3-Clause-LBNL"))
+	assert.True(t, CheckLicense("GPL-3.0+"))
+	assert.True(t, CheckLicense("Zimbra-1.3"))
+	assert.True(t, CheckLicense("xpp"))
+}

--- a/wski18n/resources/en_US.all.json
+++ b/wski18n/resources/en_US.all.json
@@ -275,5 +275,24 @@
     "id": "Failed to invoke the feed when deleting trigger feed with error message: {{.err}} and error code: {{.code}}.\n",
     "translation": "Failed to invoke the feed when deleting trigger feed with error message: {{.err}} and error code: {{.code}}.\n"
   }
-
+  {
+    "id": "WARNING: Mandatory field Package Version must be set.\n",
+    "translation": "WARNING: Mandatory field Package Version must be set.\n"
+  }
+  {
+    "id": "WARNING: Package Version is not saved in the current wskdeploy version.\n",
+    "translation": "WARNING: Package Version is not saved in the current wskdeploy version.\n"
+  }
+  {
+    "id": "WARNING: Mandatory field Package License must be set.\n",
+    "translation": "WARNING: Mandatory field Package License must be set.\n"
+  }
+  {
+    "id": "WARNING: Package License is not saved in the current wskdeploy version.\n",
+    "translation": "WARNING: Package License is not saved in the current wskdeploy version.\n"
+  }
+  {
+    "id": "WARNING: License {{.licenseID}} is not a valid one.\n",
+    "translation": "WARNING: License {{.licenseID}} is not a valid one.\n"
+  }
 ]


### PR DESCRIPTION
Closes #507 
Closes #508 

This PR will check the mandatory field "Version" and "License". If they are not exist, it will print two warning messages:
```
WARNING: Mandatory field Package Version must be set.
WARNING: Package Version is not saved in the current wskdeploy version.
```

This PR contains a validation check of a License. Firstly, it will check the license based on a local popular license list with a high performance. If the local check is failed, it will check based on a remote json file, with a lower performance.