### PR TITLE
Update the readme of i18n tooling

### DIFF
--- a/wski18n/README.md
+++ b/wski18n/README.md
@@ -11,7 +11,7 @@ $ go get -u github.com/jteeuwen/go-bindata/...
 Then, go the HOME directory of wskdeploy and run the following command:
 
 ```
-$ go-bindata -pkg wski18n -o wski18n/i18n_resources.go wski18n/resources;
+$ $GOPATH/bin/go-bindata -pkg wski18n -o wski18n/i18n_resources.go wski18n/resources;
 ```
 
 Finally, add the default ASF license header to i18n_resources.go. Since each file of


### PR DESCRIPTION
This doc works for me.

But, the format of the generated go file is different from the current one. Tab is set to 8 spaces in my env, so a lot of space changes lines will appear in the diff report.