### PR TITLE
Silence Usage on error

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,6 +49,8 @@ wskdeploy without any commands or flags deploys openwhisk package in the current
 }
 
 func RootCmdImp(cmd *cobra.Command, args []string) error {
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
 	return Deploy()
 }
 


### PR DESCRIPTION
Closes #569 

**Fix:**

- Silence Usage in case of failure
- Quiet printing errors from `cmd.Execute()`

**Before:**

```
./wskdeploy 
Error: /Users/pritidesai/Documents/goworkspace/src/github.com/apache/incubator-openwhisk-wskdeploy/cmd/root.go [178]: Invalid input of Yaml file =====> Missing {{.yaml}}/{{.yml}} file. Manifest file not found at path {{.projectPath}}.


Usage:
  wskdeploy [flags]
  wskdeploy [command]

Available Commands:
  add         Add an action, feed, trigger or rule to the manifest
  help        Help about any command
  init        Init helps you create a manifest file on OpenWhisk
  publish     Publish a package to a registry
  report      Returns summary of what's been deployed on OpenWhisk in specific namespace
  undeploy    Undeploy assets from OpenWhisk
  version     Print the version number of openwhisk-wskdeploy

Flags:
  -a, --allow-defaults       allow defaults
  -i, --allow-interactive    allow interactive prompts
      --apihost string       whisk API HOST
      --apiversion VERSION   whisk API VERSION
  -u, --auth KEY             authorization KEY
      --config string        config file (default is $HOME/.wskprops)
  -d, --deployment string    path to deployment file
  -h, --help                 help for wskdeploy
  -m, --manifest string      path to manifest file
  -n, --namespace string     namespace
  -p, --project string       path to serverless project (default ".")
  -s, --strict               allow user defined runtime version
  -t, --toggle               Help message for toggle
  -v, --verbose              verbose output

Use "wskdeploy [command] --help" for more information about a command.

Error: /Users/pritidesai/Documents/goworkspace/src/github.com/apache/incubator-openwhisk-wskdeploy/cmd/root.go [178]: Invalid input of Yaml file =====> Missing {{.yaml}}/{{.yml}} file. Manifest file not found at path {{.projectPath}}.
```

**After:**

```
./wskdeploy 
Error: /Users/pritidesai/Documents/goworkspace/src/github.com/apache/incubator-openwhisk-wskdeploy/cmd/root.go [180]: Invalid input of Yaml file =====> Missing {{.yaml}}/{{.yml}} file. Manifest file not found at path {{.projectPath}}.
```