### PR TITLE
Use "YAML: Parsing errors:" as the header for parsing erros

### DIFF
--- a/parsers/deploy_parser_test.go
+++ b/parsers/deploy_parser_test.go
@@ -55,7 +55,7 @@ func TestInvalidKeyDeploymentYaml(t *testing.T) {
     _, err = p.ParseDeployment(tmpfile.Name())
     assert.NotNil(t, err)
     // go-yaml/yaml prints the wrong line number for mapping values. It should be 3.
-    assert.Contains(t, err.Error(), "field invalidKey not found in struct parsers.Application: Line 2, its neighbour lines, or the lines on the same level")
+    assert.Contains(t, err.Error(), "field invalidKey not found in struct parsers.Application: Line 2, its neighbor lines, or the lines on the same level")
 }
 
 func TestMappingValueDeploymentYaml(t *testing.T) {
@@ -74,7 +74,7 @@ func TestMappingValueDeploymentYaml(t *testing.T) {
     _, err = p.ParseDeployment(tmpfile.Name())
     assert.NotNil(t, err)
     // go-yaml/yaml prints the wrong line number for mapping values. It should be 3.
-    assert.Contains(t, err.Error(), "mapping values are not allowed in this context: Line 2, its neighbour lines, or the lines on the same level")
+    assert.Contains(t, err.Error(), "mapping values are not allowed in this context: Line 2, its neighbor lines, or the lines on the same level")
 }
 
 func TestMissingRootNodeDeploymentYaml(t *testing.T) {
@@ -91,7 +91,7 @@ func TestMissingRootNodeDeploymentYaml(t *testing.T) {
     _, err = p.ParseDeployment(tmpfile.Name())
     assert.NotNil(t, err)
     // go-yaml/yaml prints the wrong line number for mapping values. It should be 3.
-    assert.Contains(t, err.Error(), "field name not found in struct parsers.YAML: Line 1, its neighbour lines, or the lines on the same level")
+    assert.Contains(t, err.Error(), "field name not found in struct parsers.YAML: Line 1, its neighbor lines, or the lines on the same level")
 }
 
 func TestParseDeploymentYAML_Application(t *testing.T) {

--- a/parsers/manifest_parser_test.go
+++ b/parsers/manifest_parser_test.go
@@ -1256,7 +1256,7 @@ func TestInvalidKeyManifestYaml(t *testing.T) {
     _, err = p.ParseManifest(tmpfile.Name())
     assert.NotNil(t, err)
     // go-yaml/yaml prints the wrong line number for mapping values. It should be 4.
-    assert.Contains(t, err.Error(), "field invalidKey not found in struct parsers.Package: Line 2, its neighbour lines, or the lines on the same level")
+    assert.Contains(t, err.Error(), "field invalidKey not found in struct parsers.Package: Line 2, its neighbor lines, or the lines on the same level")
 }
 
 func TestMappingValueManifestYaml(t *testing.T) {
@@ -1277,7 +1277,7 @@ func TestMappingValueManifestYaml(t *testing.T) {
     _, err = p.ParseManifest(tmpfile.Name())
     assert.NotNil(t, err)
     // go-yaml/yaml prints the wrong line number for mapping values. It should be 5.
-    assert.Contains(t, err.Error(), "mapping values are not allowed in this context: Line 4, its neighbour lines, or the lines on the same level")
+    assert.Contains(t, err.Error(), "mapping values are not allowed in this context: Line 4, its neighbor lines, or the lines on the same level")
 }
 
 func TestMissingRootValueManifestYaml(t *testing.T) {
@@ -1295,7 +1295,7 @@ func TestMissingRootValueManifestYaml(t *testing.T) {
     p := NewYAMLParser()
     _, err = p.ParseManifest(tmpfile.Name())
     assert.NotNil(t, err)
-    assert.Contains(t, err.Error(), "field actions not found in struct parsers.YAML: Line 1, its neighbour lines, or the lines on the same level")
+    assert.Contains(t, err.Error(), "field actions not found in struct parsers.YAML: Line 1, its neighbor lines, or the lines on the same level")
 
 }
 

--- a/utils/wskdeployerror.go
+++ b/utils/wskdeployerror.go
@@ -31,6 +31,7 @@ const (
     MANIFEST_NOT_FOUND = INVALID_YAML_INPUT
     UNKNOWN = "Unknown"
     LINE = "line"
+    PARSING_ERR = "YAML: Parsing errors:"
 )
 
 type TestCaseError struct {
@@ -186,9 +187,9 @@ func (e *ParserErr) Error() string {
     for index, each := range e.msgs {
         var s string
         if e.lines[index] == UNKNOWN {
-            s = fmt.Sprintf("%s", each)
+            s = fmt.Sprintf("%s", PARSING_ERR)
         } else {
-            s = fmt.Sprintf("%s: Line %s, its neighbour lines, or the lines on the same level.", each, e.lines[index])
+            s = fmt.Sprintf("%s: Line %s, its neighbor lines, or the lines on the same level.", each, e.lines[index])
         }
         result[index] = s
     }


### PR DESCRIPTION
Closes #506