### PR TITLE
changing rule/trigger names and removing dependency for now

### DIFF
--- a/tests/src/integration/validate-packages-in-manifest/manifest.yaml
+++ b/tests/src/integration/validate-packages-in-manifest/manifest.yaml
@@ -1,10 +1,10 @@
 packages:
     packageNodeJS:
-        dependencies:
-            hellowhisk:
-                location: github.com/apache/incubator-openwhisk-test/packages/hellowhisk
-            myhelloworlds:
-                location: github.com/apache/incubator-openwhisk-test/packages/helloworlds
+#        dependencies:
+#            hellowhisk:
+#                location: github.com/apache/incubator-openwhisk-test/packages/hellowhisk
+#            myhelloworlds:
+#                location: github.com/apache/incubator-openwhisk-test/packages/helloworlds
         actions:
             helloNodejs-1:
                 function: actions/hello.js
@@ -35,19 +35,19 @@ packages:
                         description: location of a person
         sequences:
             helloworldnodejs-series:
-                actions: helloNodejs-1, helloNodejs-2, helloNodejs-3, hellowhisk/greeting, hellowhisk/httpGet, myhelloworlds/hello-js
+                actions: helloNodejs-1, helloNodejs-2, helloNodejs-3 #, hellowhisk/greeting, hellowhisk/httpGet, myhelloworlds/hello-js
         triggers:
-            triggerNodeJS:
+            triggerNodeJS1:
         rules:
-            ruleNodeJS:
-                trigger: triggerNodeJS
+            ruleNodeJS1:
+                trigger: triggerNodeJS1
                 action: helloworldnodejs-series
     packagePython:
-        dependencies:
-            hellowhisk:
-                location: github.com/apache/incubator-openwhisk-test/packages/hellowhisk
-            helloworlds:
-                location: github.com/apache/incubator-openwhisk-test/packages/helloworlds
+#        dependencies:
+#            hellowhisk:
+#                location: github.com/apache/incubator-openwhisk-test/packages/hellowhisk
+#            helloworlds:
+#                location: github.com/apache/incubator-openwhisk-test/packages/helloworlds
         actions:
             helloPython-1:
                 function: actions/hello.py
@@ -76,7 +76,7 @@ packages:
                 runtime: python
         sequences:
             helloworldpython-series:
-                actions: helloPython-1, helloPython-2, helloPython-3, hellowhisk/greeting, hellowhisk/httpGet, helloworlds/hello-js
+                actions: helloPython-1, helloPython-2, helloPython-3 #, hellowhisk/greeting, hellowhisk/httpGet, helloworlds/hello-js
         triggers:
             triggerPython:
         rules:
@@ -111,12 +111,3 @@ packages:
             ruleJava:
                 trigger: triggerJava
                 action: helloJava-1
-    packageBuggy:
-        actions:
-            helloJava-1:
-                function: actions/hello.jar
-                runtime: java
-                main: Hello
-        triggers:
-            triggerJava:
-


### PR DESCRIPTION
this is an attempt to fix build failure on master, this is just a temporary fix, we need to address the concurrent access issue by adding lock to an individual resource, have to investigate where we can apply such lock in `wskdeploy` or go client or `openwhisk` itself.

The biggest issue we have right now in `wskdeploy` is `rules` and `triggers` are created outside of the `package` which results in concurrent access of `rules` and `triggers` from different manifest files but named same.
