### PR TITLE
Fixes #289 Typo in constructor 'NewManfiestReader' in file manifestreader.go

### DIFF
--- a/deployers/manifestreader.go
+++ b/deployers/manifestreader.go
@@ -34,7 +34,7 @@ type ManifestReader struct {
 	IsUndeploy      bool
 }
 
-func NewManfiestReader(serviceDeployer *ServiceDeployer) *ManifestReader {
+func NewManifestReader(serviceDeployer *ServiceDeployer) *ManifestReader {
 	var dep ManifestReader
 	dep.serviceDeployer = serviceDeployer
 

--- a/deployers/manifestreader_test.go
+++ b/deployers/manifestreader_test.go
@@ -33,7 +33,7 @@ func init() {
 
 	sd = NewServiceDeployer()
 	sd.ManifestPath = manifest_file
-	mr = NewManfiestReader(sd)
+	mr = NewManifestReader(sd)
 	ps = parsers.NewYAMLParser()
 	ms, _ = ps.ParseManifest(manifest_file)
 }

--- a/deployers/servicedeployer.go
+++ b/deployers/servicedeployer.go
@@ -112,7 +112,7 @@ func (deployer *ServiceDeployer) Check() {
 
 func (deployer *ServiceDeployer) ConstructDeploymentPlan() error {
 
-	var manifestReader = NewManfiestReader(deployer)
+	var manifestReader = NewManifestReader(deployer)
 	manifestReader.IsUndeploy = false
 	var err error
 	manifest, manifestParser, err := manifestReader.ParseManifest()
@@ -185,7 +185,7 @@ func (deployer *ServiceDeployer) ConstructDeploymentPlan() error {
 
 func (deployer *ServiceDeployer) ConstructUnDeploymentPlan() (*DeploymentProject, error) {
 
-	var manifestReader = NewManfiestReader(deployer)
+	var manifestReader = NewManifestReader(deployer)
 	manifestReader.IsUndeploy = true
 	var err error
 	manifest, manifestParser, err := manifestReader.ParseManifest()

--- a/parsers/manifest_parser_test.go
+++ b/parsers/manifest_parser_test.go
@@ -528,7 +528,7 @@ func TestComposeActionsForInvalidRuntime(t *testing.T) {
     }
 }
 
-// Test 11: validate manfiest_parser.ComposeActions() method for single line parameters
+// Test 11: validate manifest_parser.ComposeActions() method for single line parameters
 // manifest_parser should be able to parse input section with different types of values
 func TestComposeActionsForSingleLineParams(t *testing.T) {
     // manifest file is located under ../tests folder
@@ -687,7 +687,7 @@ func TestComposeActionsForSingleLineParams(t *testing.T) {
     }
 }
 
-// Test 12: validate manfiest_parser.ComposeActions() method for multi line parameters
+// Test 12: validate manifest_parser.ComposeActions() method for multi line parameters
 // manifest_parser should be able to parse input section with different types of values
 func TestComposeActionsForMultiLineParams(t *testing.T) {
     // manifest file is located under ../tests folder
@@ -761,7 +761,7 @@ func TestComposeActionsForMultiLineParams(t *testing.T) {
     }
 }
 
-// Test 13: validate manfiest_parser.ComposeActions() method
+// Test 13: validate manifest_parser.ComposeActions() method
 func TestComposeActionsForFunction(t *testing.T) {
     data :=
         `package:
@@ -802,7 +802,7 @@ func TestComposeActionsForFunction(t *testing.T) {
 
 }
 
-// Test 14: validate manfiest_parser.ComposeActions() method
+// Test 14: validate manifest_parser.ComposeActions() method
 func TestComposeActionsForLimits (t *testing.T) {
   data :=
 `package:
@@ -850,7 +850,7 @@ func TestComposeActionsForLimits (t *testing.T) {
   }
 }
 
-// Test 15: validate manfiest_parser.ComposeActions() method
+// Test 15: validate manifest_parser.ComposeActions() method
 func TestComposeActionsForWebActions(t *testing.T) {
     data :=
         `package:
@@ -1628,4 +1628,3 @@ func TestComposeActionForAnnotations(t *testing.T) {
     eq = reflect.DeepEqual(actual_annotations, expected_annotations)
     assert.True(t, eq, "Expected list of annotations does not match with actual list, expected annotations: %v actual annotations: %v", expected_annotations, actual_annotations)
 }
-


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-openwhisk-wskdeploy/issues/289