### PR TITLE
Fixes #290 Change util_test.go's ReadUrl test URL to a neutral address

### DIFF
--- a/utils/misc_test.go
+++ b/utils/misc_test.go
@@ -38,7 +38,7 @@ func TestLocalReader_ReadLocal(t *testing.T) {
 }
 
 func TestURLReader_ReadUrl(t *testing.T) {
-	var exampleUrl = "http://www.baidu.com"
+	var exampleUrl = "https://www.apache.org/"
 	b, _ := contentReader.ReadUrl(exampleUrl)
 	if b == nil {
 		t.Error("get web content failed")


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-openwhisk-wskdeploy/issues/290