### PR TITLE
Uncommenting managed deployment for rules, package, actions, and sequences

### DIFF
--- a/deployers/servicedeployer.go
+++ b/deployers/servicedeployer.go
@@ -476,13 +476,13 @@ func (deployer *ServiceDeployer) RefreshManagedEntities(maValue whisk.KeyValue) 
 		return err
 	}
 
-	//if err := deployer.RefreshManagedRules(ma); err != nil {
-	//	return err
-	//}
+	if err := deployer.RefreshManagedRules(ma); err != nil {
+		return err
+	}
 
-	//if err := deployer.RefreshManagedPackages(ma); err != nil {
-	//	return err
-	//}
+	if err := deployer.RefreshManagedPackages(ma); err != nil {
+		return err
+	}
 
 	return nil
 

--- a/parsers/manifest_parser.go
+++ b/parsers/manifest_parser.go
@@ -439,7 +439,7 @@ func (dm *YAMLParser) ComposeActions(filePath string, actions map[string]Action,
 
 				switch ext {
 				case ".swift":
-					kind = "swift:3"
+					kind = "swift:3.1.1"
 				case ".js":
 					kind = "nodejs:6"
 				case ".py":

--- a/parsers/manifest_parser_test.go
+++ b/parsers/manifest_parser_test.go
@@ -486,7 +486,7 @@ func TestComposeActionsForImplicitRuntimes(t *testing.T) {
                     } else if actions[i].Action.Name == "helloPython" {
                         expectedResult = "python"
                     } else if actions[i].Action.Name == "helloSwift" {
-                        expectedResult = "swift:3"
+                        expectedResult = "swift:3.1.1"
                     }
                     actualResult := actions[i].Action.Exec.Kind
                     assert.Equal(t, expectedResult, actualResult, "Expected " + expectedResult + " but got " + actualResult)

--- a/tests/src/integration/runtimetests/manifest.yaml
+++ b/tests/src/integration/runtimetests/manifest.yaml
@@ -94,7 +94,7 @@ packages:
           web-export: true
           version: 1.0
           function: src/hello.swift
-          runtime: swift:3
+          runtime: swift:3.1.1
           inputs:
             name: string
             place: string

--- a/utils/misc.go
+++ b/utils/misc.go
@@ -543,10 +543,10 @@ var runtimeInfo = []byte(`{
 var Rts map[string][]string
 
 var DefaultRts = map[string][]string{
-	"nodejs": {"nodejs:6", "nodejs:8"},
+	"nodejs": {"nodejs:6"},
 	"java":   {"java"},
 	"php":    {"php:7.1"},
-	"python": {"python", "python:2", "python:3"},
+	"python": {"python:2"},
 	"swift":  {"swift:3.1.1"},
 }
 

--- a/utils/misc.go
+++ b/utils/misc.go
@@ -539,7 +539,7 @@ var DefaultRts = map[string][]string{
 	"java":   {"java"},
 	"php":    {"php:7.1"},
 	"python": {"python", "python:2", "python:3"},
-	"swift":  {"swift", "swift:3", "swift:3.1.1"},
+	"swift":  {"swift:3.1.1"},
 }
 
 func CheckExistRuntime(rtname string, rts map[string][]string) bool {

--- a/utils/misc.go
+++ b/utils/misc.go
@@ -441,101 +441,109 @@ func ConvertToMap(op OpenWhiskInfo) (rt map[string][]string) {
 }
 
 var runtimeInfo = []byte(`{
-  "support": {
-    "github": "https://github.com/apache/incubator-openwhisk/issues",
-    "slack": "http://slack.openwhisk.org"
-  },
-  "description": "OpenWhisk",
-  "api_paths": ["/api/v1"],
-  "runtimes": {
-    "nodejs": [{
-      "image": "openwhisk/nodejsaction:latest",
-      "deprecated": true,
-      "requireMain": false,
-      "default": false,
-      "attached": false,
-      "kind": "nodejs"
-    }, {
-      "image": "openwhisk/nodejs6action:latest",
-      "deprecated": false,
-      "requireMain": false,
-      "default": true,
-      "attached": false,
-      "kind": "nodejs:6"
-    }],
-    "java": [{
-      "image": "openwhisk/java8action:latest",
-      "deprecated": false,
-      "requireMain": true,
-      "default": true,
-      "attached": true,
-      "kind": "java"
-    }],
-    "php": [{
-      "image": "openwhisk/action-php-v7.1:latest",
-      "deprecated": false,
-      "requireMain": false,
-      "default": true,
-      "attached": false,
-      "kind": "php:7.1"
-    }],
-    "python": [{
-      "image": "openwhisk/python2action:latest",
-      "deprecated": false,
-      "requireMain": false,
-      "default": false,
-      "attached": false,
-      "kind": "python"
-    }, {
-      "image": "openwhisk/python2action:latest",
-      "deprecated": false,
-      "requireMain": false,
-      "default": true,
-      "attached": false,
-      "kind": "python:2"
-    }, {
-      "image": "openwhisk/python3action:latest",
-      "deprecated": false,
-      "requireMain": false,
-      "default": false,
-      "attached": false,
-      "kind": "python:3"
-    }],
-    "swift": [{
-      "image": "openwhisk/swiftaction:latest",
-      "deprecated": true,
-      "requireMain": false,
-      "default": false,
-      "attached": false,
-      "kind": "swift"
-    }, {
-      "image": "openwhisk/swift3action:latest",
-      "deprecated": false,
-      "requireMain": false,
-      "default": true,
-      "attached": false,
-      "kind": "swift:3"
-    }, {
-      "image": "openwhisk/action-swift-v3.1.1:latest",
-      "deprecated": false,
-      "requireMain": false,
-      "default": false,
-      "attached": false,
-      "kind": "swift:3.1.1"
-    }]
-  },
-  "limits": {
-    "actions_per_minute": 5000,
-    "triggers_per_minute": 5000,
-    "concurrent_actions": 1000
-  }
-  }
+	"support":{
+		"github":"https://github.com/apache/incubator-openwhisk/issues",
+		"slack":"http://slack.openwhisk.org"
+	},
+	"description":"OpenWhisk",
+	"api_paths":["/api/v1"],
+	"runtimes":{
+		"nodejs":[{
+			"image":"openwhisk/nodejsaction:latest",
+			"deprecated":true,
+			"requireMain":false,
+			"default":false,
+			"attached":false,
+			"kind":"nodejs"
+		},{
+			"image":"openwhisk/nodejs6action:latest",
+			"deprecated":false,
+			"requireMain":false,
+			"default":true,
+			"attached":false,
+			"kind":"nodejs:6"
+		},{
+			"image":"openwhisk/action-nodejs-v8:latest",
+			"deprecated":false,
+			"requireMain":false,
+			"default":false,
+			"attached":false,
+			"kind":"nodejs:8"
+		}],
+		"java":[{
+			"image":"openwhisk/java8action:latest",
+			"deprecated":false,
+			"requireMain":true,
+			"default":true,
+			"attached":true,
+			"kind":"java"
+		}],
+		"php":[{
+			"image":"openwhisk/action-php-v7.1:latest",
+			"deprecated":false,
+			"requireMain":false,
+			"default":true,
+			"attached":false,
+			"kind":"php:7.1"
+		}],
+		"python":[{
+			"image":"openwhisk/python2action:latest",
+			"deprecated":false,
+			"requireMain":false,
+			"default":false,
+			"attached":false,
+			"kind":"python"
+		},{
+			"image":"openwhisk/python2action:latest",
+			"deprecated":false,
+			"requireMain":false,
+			"default":true,
+			"attached":false,
+			"kind":"python:2"
+		},{
+			"image":"openwhisk/python3action:latest",
+			"deprecated":false,
+			"requireMain":false,
+			"default":false,
+			"attached":false,
+			"kind":"python:3"
+		}],
+		"swift":[{
+			"image":"openwhisk/swiftaction:latest",
+			"deprecated":true,
+			"requireMain":false,
+			"default":false,
+			"attached":false,
+			"kind":"swift"
+		},{
+			"image":"openwhisk/swift3action:latest",
+			"deprecated":true,
+			"requireMain":false,
+			"default":false,
+			"attached":false,
+			"kind":"swift:3"
+		},{
+			"image":"openwhisk/action-swift-v3.1.1:latest",
+			"deprecated":false,
+			"requireMain":false,
+			"default":true,
+			"attached":false,
+			"kind":"swift:3.1.1"
+		}]
+	},
+	"limits":{
+		"actions_per_minute":5000,
+		"triggers_per_minute":5000,
+		"concurrent_actions":1000
+	}
+	}
 `)
+
 
 var Rts map[string][]string
 
 var DefaultRts = map[string][]string{
-	"nodejs": {"nodejs", "nodejs:6"},
+	"nodejs": {"nodejs:6", "nodejs:8"},
 	"java":   {"java"},
 	"php":    {"php:7.1"},
 	"python": {"python", "python:2", "python:3"},

--- a/utils/misc_test.go
+++ b/utils/misc_test.go
@@ -85,11 +85,11 @@ func TestParseOpenWhisk(t *testing.T) {
 	openwhisk, err := ParseOpenWhisk(openwhiskHost)
 	assert.Equal(t, nil, err, "parse openwhisk info error happened.")
 	converted := ConvertToMap(openwhisk)
-	assert.Equal(t, 1, len(converted["nodejs"]), "not expected length")
+	assert.Equal(t, 2, len(converted["nodejs"]), "not expected length")
 	assert.Equal(t, 1, len(converted["php"]),  "not expected length")
 	assert.Equal(t, 1, len(converted["java"]), "not expected length")
 	assert.Equal(t, 3, len(converted["python"]), "not expected length")
-	assert.Equal(t, 2, len(converted["swift"]), "not expected length")
+	assert.Equal(t, 1, len(converted["swift"]), "not expected length")
 }
 
 func TestNewZipWritter(t *testing.T) {


### PR DESCRIPTION
After spending an hour the night before a big showcase on Tuesday, found these few lines commented out which was causing managed deployment to fail :(