### PR TITLE
Adding message hub test back

### DIFF
--- a/tests/src/integration/message-hub/deployment.yaml
+++ b/tests/src/integration/message-hub/deployment.yaml
@@ -8,7 +8,7 @@ project:
                         messagehub_instance: wskdeployMessageHub
                         topic:  $DESTINATION_TOPIC
             triggers:
-                wskdeployMessageHubTrigger:
+                wskdeployIntegrationTestMessageHubTrigger:
                     inputs:
                         isJSONData: true
                         topic: $SOURCE_TOPIC

--- a/tests/src/integration/message-hub/manifest.yaml
+++ b/tests/src/integration/message-hub/manifest.yaml
@@ -20,11 +20,11 @@ packages:
             data-processing-sequence:
                 actions: receive-messages-from-messagehub, process-messages-received-from-messagehub
         triggers:
-            wskdeployMessageHubTrigger:
+            wskdeployIntegrationTestMessageHubTrigger:
                 feed: wskdeployMessageHub/messageHubFeed
         rules:
             data-processing-rule:
-                trigger: wskdeployMessageHubTrigger
+                trigger: wskdeployIntegrationTestMessageHubTrigger
                 action: data-processing-sequence
 
 

--- a/wskderrors/wskdeployerror.go
+++ b/wskderrors/wskdeployerror.go
@@ -22,6 +22,8 @@ import (
 	"runtime"
 	"strings"
 	"path/filepath"
+	"net/http"
+	"io/ioutil"
 )
 
 const (
@@ -38,6 +40,8 @@ const (
 	STR_ACTION = "Action"
 	STR_RUNTIME = "Runtime"
 	STR_SUPPORTED_RUNTIMES = "Supported Runtimes"
+	STR_HTTP_STATUS = "HTTP Response Status"
+	STR_HTTP_BODY = "HTTP Response Body"
 
 	// Formatting
 	STR_INDENT_1 = "==>"
@@ -169,14 +173,15 @@ type WhiskClientError struct {
 	ErrorCode int
 }
 
-func NewWhiskClientError(errorMessage string, code int) *WhiskClientError {
+func NewWhiskClientError(errorMessage string, code int, response *http.Response) *WhiskClientError {
 	var err = &WhiskClientError{
 		ErrorCode: code,
 	}
 	err.SetErrorType(ERROR_WHISK_CLIENT_ERROR)
 	err.SetCallerByStackFrameSkip(2)
-	err.SetMessageFormat("%s: %d: %s")
-	str := fmt.Sprintf(err.MessageFormat, STR_ERROR_CODE, code, errorMessage)
+	err.SetMessageFormat("%s: %d: %s: %s: %s %s: %s")
+	responseData, _ := ioutil.ReadAll(response.Body)
+	str := fmt.Sprintf(err.MessageFormat, STR_ERROR_CODE, code, errorMessage, STR_HTTP_STATUS, response.Status, STR_HTTP_BODY, string(responseData))
 	err.SetMessage(str)
 	return err
 }

--- a/wskderrors/wskdeployerror.go
+++ b/wskderrors/wskdeployerror.go
@@ -179,9 +179,13 @@ func NewWhiskClientError(errorMessage string, code int, response *http.Response)
 	}
 	err.SetErrorType(ERROR_WHISK_CLIENT_ERROR)
 	err.SetCallerByStackFrameSkip(2)
-	err.SetMessageFormat("%s: %d: %s: %s: %s %s: %s")
-	responseData, _ := ioutil.ReadAll(response.Body)
-	str := fmt.Sprintf(err.MessageFormat, STR_ERROR_CODE, code, errorMessage, STR_HTTP_STATUS, response.Status, STR_HTTP_BODY, string(responseData))
+	err.SetMessageFormat("%s: %d: %s")
+	var str = fmt.Sprintf(err.MessageFormat, STR_ERROR_CODE, code, errorMessage)
+	if response != nil {
+		responseData, _ := ioutil.ReadAll(response.Body)
+		err.SetMessageFormat("%s: %d: %s: %s: %s %s: %s")
+		str = fmt.Sprintf(err.MessageFormat, STR_ERROR_CODE, code, errorMessage, STR_HTTP_STATUS, response.Status, STR_HTTP_BODY, string(responseData))
+	}
 	err.SetMessage(str)
 	return err
 }

--- a/wskderrors/wskdeployerror_test.go
+++ b/wskderrors/wskdeployerror_test.go
@@ -64,7 +64,7 @@ func TestCustomErrorOutputFormat(t *testing.T) {
 	/*
 	 * WhiskClientError
 	 */
-	err2 := NewWhiskClientError(TEST_DEFAULT_ERROR_MESSAGE, TEST_ERROR_CODE)
+	err2 := NewWhiskClientError(TEST_DEFAULT_ERROR_MESSAGE, TEST_ERROR_CODE, nil)
 	actualResult =  strings.TrimSpace(err2.Error())
 	expectedResult = fmt.Sprintf("%s [%d]: [%s]: %s: %d: %s",
 		packageName,


### PR DESCRIPTION
Adding integration test for message hub back. Also, added response body and status in WhiskClientError.

Integration tests were mainly failing with the trigger "wskdeployMessageHubTrigger". Integration test was successful after renaming this trigger to something else. I couldn't determine the exact cause of failure. But it was weird to see that this trigger was not part of trigger listing even after trigger was created. Also, when the POST command was run manually, it was failing with "no permission to access this resource".  There might be some conflict with some other trigger or trigger ID on OpenWhisk side as its under shared account.

Adding HTTP response info into WhiskClientError as:

```
Error: servicedeployer.go [846]: [ERROR_WHISK_CLIENT_ERROR]: Error code: 246: The following application error was received: {}: HTTP Response Status: application error HTTP Response Body: {"duration":916,"name":"messageHubFeed","subject":"*","activationId":"0cd2c08003684dd892c0800368edd888","publish":false,"annotations":[{"key":"path","value":"whisk.system/messaging/messageHubFeed"},{"key":"waitTime","value":90},{"key":"kind","value":"nodejs:6"},{"key":"limits","value":{"timeout":60000,"memory":256,"logs":10}},{"key":"initTime","value":385}],"version":"0.0.35","response":{"result":{"error":"You must supply a 'topic' parameter."},"success":false,"status":"application error"},"end":1513732045616,"logs":[],"start":1513732044700,"namespace":"*"}
```

Compared to right now:

```
Error: servicedeployer.go [846]: [ERROR_WHISK_CLIENT_ERROR]: Error code: 246: The following application error was received: {}
```
