### PR TITLE
lossen line # checks on go yaml parser as it keeps changing.

### DIFF
--- a/parsers/deploy_parser_test.go
+++ b/parsers/deploy_parser_test.go
@@ -55,7 +55,7 @@ func TestInvalidKeyDeploymentYaml(t *testing.T) {
 	_, err = p.ParseDeployment(tmpfile.Name())
 	assert.NotNil(t, err)
 	// NOTE: go-yaml/yaml gets the line # wrong; testing only for the invalid key message
-	assert.Contains(t, err.Error(), "line 3: field invalidKey not found in struct parsers.Project")
+	assert.Contains(t, err.Error(), "field invalidKey not found in struct parsers.Project")
 }
 
 func TestMappingValueDeploymentYaml(t *testing.T) {

--- a/parsers/deploy_parser_test.go
+++ b/parsers/deploy_parser_test.go
@@ -54,8 +54,8 @@ func TestInvalidKeyDeploymentYaml(t *testing.T) {
 	p := NewYAMLParser()
 	_, err = p.ParseDeployment(tmpfile.Name())
 	assert.NotNil(t, err)
-	// go-yaml/yaml prints the wrong line number for mapping values. It should be 3.
-	assert.Contains(t, err.Error(), "line 2: field invalidKey not found in struct parsers.Project")
+	// NOTE: go-yaml/yaml gets the line # wrong; testing only for the invalid key message
+	assert.Contains(t, err.Error(), "line 3: field invalidKey not found in struct parsers.Project")
 }
 
 func TestMappingValueDeploymentYaml(t *testing.T) {

--- a/parsers/manifest_parser_test.go
+++ b/parsers/manifest_parser_test.go
@@ -1400,8 +1400,8 @@ func TestBadYAMLInvalidPackageKeyInManifest(t *testing.T) {
     _, err := p.ParseManifest("../tests/dat/manifest_bad_yaml_invalid_package_key.yaml")
 
     assert.NotNil(t, err)
-    // go-yaml/yaml prints the wrong line number for mapping values. It should be 4.
-    assert.Contains(t, err.Error(), "line 2: field invalidKey not found in struct parsers.Package")
+    // NOTE: go-yaml/yaml gets the line # wrong; testing only for the invalid key message
+    assert.Contains(t, err.Error(), "field invalidKey not found in struct parsers.Package")
 }
 
 func TestBadYAMLInvalidKeyMappingValueInManifest(t *testing.T) {


### PR DESCRIPTION
go-yaml parser looks like it changed underneath us over the weekend resulting in different line #s for invalid Yaml errors.  Adjusting unit tests to be less sensitive by removing hardcoded line #s in assertions.