### PR TITLE
Adding support for raw HTTP web actions

### DIFF
--- a/parsers/manifest_parser.go
+++ b/parsers/manifest_parser.go
@@ -653,8 +653,12 @@ func (dm *YAMLParser) ComposeActions(filePath string, actions map[string]Action,
 		 *  Web Export
 		 */
 		// TODO() add boolean value const
-		if action.Webexport == "true" {
-			wskaction.Annotations, errorParser = utils.WebAction("yes", listOfAnnotations, false)
+		// Treat ACTION as a web action, a raw HTTP web action, or as a standard action based on web-export;
+		// when web-export is set to yes | true, treat action as a web action,
+		// when web-export is set to raw, treat action as a raw HTTP web action,
+		// when web-export is set to no | false, treat action as a standard action
+		if len(action.Webexport) != 0 {
+			wskaction.Annotations, errorParser = utils.WebAction(action.Webexport, listOfAnnotations, false)
 			if errorParser != nil {
 				return s1, errorParser
 			}

--- a/parsers/manifest_parser.go
+++ b/parsers/manifest_parser.go
@@ -652,13 +652,12 @@ func (dm *YAMLParser) ComposeActions(filePath string, actions map[string]Action,
 		/*
 		 *  Web Export
 		 */
-		// TODO() add boolean value const
 		// Treat ACTION as a web action, a raw HTTP web action, or as a standard action based on web-export;
 		// when web-export is set to yes | true, treat action as a web action,
 		// when web-export is set to raw, treat action as a raw HTTP web action,
 		// when web-export is set to no | false, treat action as a standard action
 		if len(action.Webexport) != 0 {
-			wskaction.Annotations, errorParser = utils.WebAction(action.Webexport, listOfAnnotations, false)
+			wskaction.Annotations, errorParser = utils.WebAction(filePath, action.Name, action.Webexport, listOfAnnotations, false)
 			if errorParser != nil {
 				return s1, errorParser
 			}

--- a/parsers/manifest_parser_test.go
+++ b/parsers/manifest_parser_test.go
@@ -949,9 +949,21 @@ func TestComposeActionsForWebActions(t *testing.T) {
 		`package:
   name: helloworld
   actions:
-    hello:
+    hello1:
       function: ../tests/src/integration/helloworld/actions/hello.js
-      web-export: true`
+      web-export: true
+    hello2:
+      function: ../tests/src/integration/helloworld/actions/hello.js
+      web-export: yes
+    hello3:
+      function: ../tests/src/integration/helloworld/actions/hello.js
+      web-export: raw
+    hello4:
+      function: ../tests/src/integration/helloworld/actions/hello.js
+      web-export: false
+    hello5:
+      function: ../tests/src/integration/helloworld/actions/hello.js
+      web-export: no`
 	dir, _ := os.Getwd()
 	tmpfile, err := ioutil.TempFile(dir, "manifest_parser_validate_web_actions_")
 	if err == nil {
@@ -963,7 +975,7 @@ func TestComposeActionsForWebActions(t *testing.T) {
 			actions, err := p.ComposeActionsFromAllPackages(m, tmpfile.Name(), whisk.KeyValue{})
 			if err == nil {
 				for i := 0; i < len(actions); i++ {
-					if actions[i].Action.Name == "hello" {
+					if actions[i].Action.Name == "hello1" {
 						for _, a := range actions[i].Action.Annotations {
 							switch a.Key {
 							case "web-export":
@@ -972,6 +984,50 @@ func TestComposeActionsForWebActions(t *testing.T) {
 								assert.Equal(t, false, a.Value, "Expected false for raw-http but got "+strconv.FormatBool(a.Value.(bool)))
 							case "final":
 								assert.Equal(t, true, a.Value, "Expected true for final but got "+strconv.FormatBool(a.Value.(bool)))
+							}
+						}
+					} else if actions[i].Action.Name == "hello2" {
+						for _, a := range actions[i].Action.Annotations {
+							switch a.Key {
+							case "web-export":
+								assert.Equal(t, true, a.Value, "Expected true for web-export but got "+strconv.FormatBool(a.Value.(bool)))
+							case "raw-http":
+								assert.Equal(t, false, a.Value, "Expected false for raw-http but got "+strconv.FormatBool(a.Value.(bool)))
+							case "final":
+								assert.Equal(t, true, a.Value, "Expected true for final but got "+strconv.FormatBool(a.Value.(bool)))
+							}
+						}
+					} else if actions[i].Action.Name == "hello3" {
+						for _, a := range actions[i].Action.Annotations {
+							switch a.Key {
+							case "web-export":
+								assert.Equal(t, true, a.Value, "Expected true for web-export but got "+strconv.FormatBool(a.Value.(bool)))
+							case "raw-http":
+								assert.Equal(t, true, a.Value, "Expected false for raw-http but got "+strconv.FormatBool(a.Value.(bool)))
+							case "final":
+								assert.Equal(t, true, a.Value, "Expected true for final but got "+strconv.FormatBool(a.Value.(bool)))
+							}
+						}
+					} else if actions[i].Action.Name == "hello4" {
+						for _, a := range actions[i].Action.Annotations {
+							switch a.Key {
+							case "web-export":
+								assert.Equal(t, false, a.Value, "Expected true for web-export but got "+strconv.FormatBool(a.Value.(bool)))
+							case "raw-http":
+								assert.Equal(t, false, a.Value, "Expected false for raw-http but got "+strconv.FormatBool(a.Value.(bool)))
+							case "final":
+								assert.Equal(t, false, a.Value, "Expected true for final but got "+strconv.FormatBool(a.Value.(bool)))
+							}
+						}
+					} else if actions[i].Action.Name == "hello5" {
+						for _, a := range actions[i].Action.Annotations {
+							switch a.Key {
+							case "web-export":
+								assert.Equal(t, false, a.Value, "Expected true for web-export but got "+strconv.FormatBool(a.Value.(bool)))
+							case "raw-http":
+								assert.Equal(t, false, a.Value, "Expected false for raw-http but got "+strconv.FormatBool(a.Value.(bool)))
+							case "final":
+								assert.Equal(t, false, a.Value, "Expected true for final but got "+strconv.FormatBool(a.Value.(bool)))
 							}
 						}
 					}

--- a/parsers/manifest_parser_test.go
+++ b/parsers/manifest_parser_test.go
@@ -1039,6 +1039,30 @@ func TestComposeActionsForWebActions(t *testing.T) {
 	}
 }
 
+// Test 15-1: validate manifest_parser.ComposeActions() method
+func TestComposeActionsForInvalidWebActions(t *testing.T) {
+	data :=
+		`package:
+  name: helloworld
+  actions:
+    hello:
+      function: ../tests/src/integration/helloworld/actions/hello.js
+      web-export: raw123`
+	dir, _ := os.Getwd()
+	tmpfile, err := ioutil.TempFile(dir, "manifest_parser_validate_invalid_web_actions_")
+	if err == nil {
+		defer os.Remove(tmpfile.Name()) // clean up
+		if _, err := tmpfile.Write([]byte(data)); err == nil {
+			// read and parse manifest.yaml file
+			p := NewYAMLParser()
+			m, _ := p.ParseManifest(tmpfile.Name())
+			_, err := p.ComposeActionsFromAllPackages(m, tmpfile.Name(), whisk.KeyValue{})
+			assert.NotNil(t, err, "Expected error for invalid web-export.")
+		}
+		tmpfile.Close()
+	}
+}
+
 // Test 16: validate manifest_parser.ResolveParameter() method
 func TestResolveParameterForMultiLineParams(t *testing.T) {
 	paramName := "name"

--- a/tests/src/integration/webaction/manifest.yml
+++ b/tests/src/integration/webaction/manifest.yml
@@ -22,7 +22,7 @@ packages:
                 outputs:
                     payload: string
             greeting-with-raw-http:
-                web-export: raw
+                web-export: raw123
                 version: 1.0
                 function: src/greeting.js
                 runtime: nodejs:6

--- a/tests/src/integration/webaction/manifest.yml
+++ b/tests/src/integration/webaction/manifest.yml
@@ -31,5 +31,5 @@ packages:
         rules:
             webActionRule:
                 trigger: webActionTrigger
-                action: greeting
+                action: greeting-web-action
 

--- a/tests/src/integration/webaction/manifest.yml
+++ b/tests/src/integration/webaction/manifest.yml
@@ -22,7 +22,7 @@ packages:
                 outputs:
                     payload: string
             greeting-with-raw-http:
-                web-export: raw123
+                web-export: raw
                 version: 1.0
                 function: src/greeting.js
                 runtime: nodejs:6

--- a/tests/src/integration/webaction/manifest.yml
+++ b/tests/src/integration/webaction/manifest.yml
@@ -1,20 +1,35 @@
 packages:
-  IntegrationTestWebAction:
-      actions:
-        greeting:
-          web-export: true
-          version: 1.0
-          function: src/greeting.js
-          runtime: nodejs:6
-          inputs:
-            name: string
-            place: string
-          outputs:
-            payload: string
-      triggers:
-        webActionTrigger:
-      rules:
-        webActionRule:
-          trigger: webActionTrigger
-          action: greeting
+    IntegrationTestWebAction:
+        actions:
+            greeting-web-action:
+                web-export: true
+                version: 1.0
+                function: src/greeting.js
+                runtime: nodejs:6
+                inputs:
+                    name: string
+                    place: string
+                outputs:
+                    payload: string
+            greeting-web-action-1:
+                web-export: yes
+                version: 1.0
+                function: src/greeting.js
+                runtime: nodejs:6
+                inputs:
+                    name: string
+                    place: string
+                outputs:
+                    payload: string
+            greeting-with-raw-http:
+                web-export: raw
+                version: 1.0
+                function: src/greeting.js
+                runtime: nodejs:6
+        triggers:
+            webActionTrigger:
+        rules:
+            webActionRule:
+                trigger: webActionTrigger
+                action: greeting
 

--- a/utils/webaction.go
+++ b/utils/webaction.go
@@ -19,8 +19,8 @@ package utils
 
 import (
 	"github.com/apache/incubator-openwhisk-client-go/whisk"
-	"strings"
 	"github.com/apache/incubator-openwhisk-wskdeploy/wskderrors"
+	"strings"
 )
 
 //for web action support, code from wsk cli with tiny adjustments
@@ -28,12 +28,12 @@ const WEB_EXPORT_ANNOT = "web-export"
 const RAW_HTTP_ANNOT = "raw-http"
 const FINAL_ANNOT = "final"
 
-var webexport map[string]string = map[string]string {
-	"TRUE": "true",
+var webexport map[string]string = map[string]string{
+	"TRUE":  "true",
 	"FALSE": "false",
-	"NO": "no",
-	"YES": "yes",
-	"RAW": "raw",
+	"NO":    "no",
+	"YES":   "yes",
+	"RAW":   "raw",
 }
 
 func WebAction(filePath string, action string, webMode string, annotations whisk.KeyValueArr, fetch bool) (whisk.KeyValueArr, error) {

--- a/utils/webaction.go
+++ b/utils/webaction.go
@@ -18,9 +18,9 @@
 package utils
 
 import (
-	"errors"
 	"github.com/apache/incubator-openwhisk-client-go/whisk"
 	"strings"
+	"github.com/apache/incubator-openwhisk-wskdeploy/wskderrors"
 )
 
 //for web action support, code from wsk cli with tiny adjustments
@@ -28,20 +28,28 @@ const WEB_EXPORT_ANNOT = "web-export"
 const RAW_HTTP_ANNOT = "raw-http"
 const FINAL_ANNOT = "final"
 
-func WebAction(webMode string, annotations whisk.KeyValueArr, fetch bool) (whisk.KeyValueArr, error) {
+var webexport map[string]string = map[string]string {
+	"TRUE": "true",
+	"FALSE": "false",
+	"NO": "no",
+	"YES": "yes",
+	"RAW": "raw",
+}
+
+func WebAction(filePath string, action string, webMode string, annotations whisk.KeyValueArr, fetch bool) (whisk.KeyValueArr, error) {
 	switch strings.ToLower(webMode) {
-	case "yes":
+	case webexport["TRUE"]:
 		fallthrough
-	case "true":
+	case webexport["YES"]:
 		return webActionAnnotations(fetch, annotations, addWebAnnotations)
-	case "no":
+	case webexport["NO"]:
 		fallthrough
-	case "false":
+	case webexport["FALSE"]:
 		return webActionAnnotations(fetch, annotations, deleteWebAnnotations)
-	case "raw":
+	case webexport["RAW"]:
 		return webActionAnnotations(fetch, annotations, addRawAnnotations)
 	default:
-		return nil, errors.New(webMode)
+		return nil, wskderrors.NewInvalidWebExportError(filePath, action, webMode, getValidWebExports())
 	}
 }
 
@@ -91,4 +99,12 @@ func deleteWebAnnotationKeys(annotations whisk.KeyValueArr) whisk.KeyValueArr {
 	annotations = deleteKey(FINAL_ANNOT, annotations)
 
 	return annotations
+}
+
+func getValidWebExports() []string {
+	var validWebExports []string
+	for _, v := range webexport {
+		validWebExports = append(validWebExports, v)
+	}
+	return validWebExports
 }

--- a/wskderrors/wskdeployerror.go
+++ b/wskderrors/wskdeployerror.go
@@ -28,20 +28,22 @@ import (
 
 const (
 	// Error message compositional strings
-	STR_UNKNOWN_VALUE      = "Unknown value"
-	STR_COMMAND            = "Command"
-	STR_ERROR_CODE         = "Error code"
-	STR_FILE               = "File"
-	STR_PARAMETER          = "Parameter"
-	STR_TYPE               = "Type"
-	STR_EXPECTED           = "Expected"
-	STR_ACTUAL             = "Actual"
-	STR_NEWLINE            = "\n"
-	STR_ACTION             = "Action"
-	STR_RUNTIME            = "Runtime"
-	STR_SUPPORTED_RUNTIMES = "Supported Runtimes"
-	STR_HTTP_STATUS        = "HTTP Response Status"
-	STR_HTTP_BODY          = "HTTP Response Body"
+	STR_UNKNOWN_VALUE         = "Unknown value"
+	STR_COMMAND               = "Command"
+	STR_ERROR_CODE            = "Error code"
+	STR_FILE                  = "File"
+	STR_PARAMETER             = "Parameter"
+	STR_TYPE                  = "Type"
+	STR_EXPECTED              = "Expected"
+	STR_ACTUAL                = "Actual"
+	STR_NEWLINE               = "\n"
+	STR_ACTION                = "Action"
+	STR_RUNTIME               = "Runtime"
+	STR_SUPPORTED_RUNTIMES    = "Supported Runtimes"
+	STR_HTTP_STATUS           = "HTTP Response Status"
+	STR_HTTP_BODY             = "HTTP Response Body"
+	STR_SUPPORTED_WEB_EXPORTS = "Supported Web Exports"
+	STR_WEB_EXPORT            = "web-export"
 
 	// Formatting
 	STR_INDENT_1 = "==>"
@@ -57,6 +59,7 @@ const (
 	ERROR_YAML_PARAMETER_TYPE_MISMATCH = "ERROR_YAML_PARAMETER_TYPE_MISMATCH"
 	ERROR_YAML_INVALID_PARAMETER_TYPE  = "ERROR_YAML_INVALID_PARAMETER_TYPE"
 	ERROR_YAML_INVALID_RUNTIME         = "ERROR_YAML_INVALID_RUNTIME"
+	ERROR_YAML_INVALID_WEB_EXPORT      = "ERROR_YAML_INVALID_WEB_EXPORT"
 )
 
 /*
@@ -381,6 +384,29 @@ func NewInvalidRuntimeError(errMessage string, fpath string, action string, runt
 	return err
 }
 
+/*
+ * InvalidWebExport
+ */
+type InvalidWebExportError struct {
+	FileError
+	Webexport           string
+	SupportedWebexports []string
+}
+
+func NewInvalidWebExportError(fpath string, action string, webexport string, supportedWebexports []string) *InvalidWebExportError {
+	var err = &InvalidWebExportError{
+		SupportedWebexports: supportedWebexports,
+	}
+	err.SetErrorFilePath(fpath)
+	err.SetErrorType(ERROR_YAML_INVALID_WEB_EXPORT)
+	err.SetCallerByStackFrameSkip(2)
+	str := fmt.Sprintf("%s [%s]: %s [%s]: %s [%s]",
+		STR_ACTION, action,
+		STR_WEB_EXPORT, webexport,
+		STR_SUPPORTED_WEB_EXPORTS, strings.Join(supportedWebexports, ", "))
+	err.SetMessage(str)
+	return err
+}
 func IsCustomError(err error) bool {
 
 	switch err.(type) {


### PR DESCRIPTION
Closes #704 

This is how you can set an action to be raw http web action:

```
packages:
    IntegrationTestWebAction:
        actions:
            greeting:
                web-export: raw
                function: src/greeting.js
```