### PR TITLE
Adding support for export managed project back to manifest

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -187,14 +187,18 @@ func ExportCmdImp(cmd *cobra.Command, args []string) error {
 			// decode the JSON blob and retrieve __OW_PROJECT_NAME
 			ta := a.(map[string]interface{})
 			if ta[utils.OW_PROJECT_NAME] == projectName {
-				for _, pkg := range maniyaml.Packages {
-					if pkg.Namespace == trg.Namespace {
-						if pkg.Triggers == nil {
+
+				//				for i := 0; i < len(maniyaml.Packages); i++ {
+				for pkgName, _ := range maniyaml.Packages {
+					if maniyaml.Packages[pkgName].Namespace == trg.Namespace {
+						if maniyaml.Packages[pkgName].Triggers == nil {
+							pkg := maniyaml.Packages[pkgName]
 							pkg.Triggers = make(map[string]parsers.Trigger)
+							maniyaml.Packages[pkgName] = pkg
 						}
 
 						// export trigger to manifest
-						pkg.Triggers[trg.Name] = *maniyaml.ComposeParsersTrigger(trg)
+						maniyaml.Packages[pkgName].Triggers[trg.Name] = *maniyaml.ComposeParsersTrigger(trg)
 					}
 				}
 			}
@@ -217,20 +221,22 @@ func ExportCmdImp(cmd *cobra.Command, args []string) error {
 		ruleTrigger := rule.Trigger.(map[string]interface{})["name"].(string)
 
 		// can be simplified once rules moved to top level next to triggers
-		for _, pkg := range maniyaml.Packages {
-			if pkg.Namespace == rule.Namespace {
+		for pkgName, _ := range maniyaml.Packages {
+			if maniyaml.Packages[pkgName].Namespace == rule.Namespace {
 				// iterate over all managed actions  in manifest
-				for _, action := range pkg.Actions {
+				for _, action := range maniyaml.Packages[pkgName].Actions {
 					if action.Name == ruleAction {
-						for _, trigger := range pkg.Triggers {
+						for _, trigger := range maniyaml.Packages[pkgName].Triggers {
 							// check that managed action and trigger equals to rule action and trigger
 							if ruleTrigger == trigger.Name && trigger.Namespace == rule.Namespace {
-								if pkg.Rules == nil {
+								if maniyaml.Packages[pkgName].Rules == nil {
+									pkg := maniyaml.Packages[pkgName]
 									pkg.Rules = make(map[string]parsers.Rule)
+									maniyaml.Packages[pkgName] = pkg
 								}
 
 								// export rule to manifest
-								pkg.Rules[rule.Name] = *maniyaml.ComposeParsersRule(rl)
+								maniyaml.Packages[pkgName].Rules[rule.Name] = *maniyaml.ComposeParsersRule(rl)
 							}
 						}
 					}

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -82,9 +82,17 @@ func ExportAction(actionName string, packageName string, maniyaml *parsers.YAML)
 		ext := utils.FileRuntimeExtensionsMap[wskAction.Exec.Kind]
 
 		manifestDir := filepath.Dir(utils.Flags.ManifestPath)
-		functionFile := filepath.Join(manifestDir, wskAction.Name) + "." + ext
+
+		// store function file under action package name subdirectory in the specified manifest folder
+		functionDir := filepath.Join(manifestDir, packageName)
+		os.MkdirAll(functionDir, os.ModePerm)
+
+		// store function in manifest under path relative to manifest root
+		functionFile := filepath.Join(packageName, wskAction.Name) + "." + ext
 		parsedAction.Function = functionFile
 
+		// create function file at the full path
+		functionFile = filepath.Join(manifestDir, functionFile)
 		f, err := os.Create(functionFile)
 		if err != nil {
 			return wskderrors.NewFileReadError(functionFile, err.Error())

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -1,0 +1,252 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/apache/incubator-openwhisk-client-go/whisk"
+	"github.com/apache/incubator-openwhisk-wskdeploy/deployers"
+	"github.com/apache/incubator-openwhisk-wskdeploy/parsers"
+	"github.com/apache/incubator-openwhisk-wskdeploy/utils"
+	"github.com/apache/incubator-openwhisk-wskdeploy/wskderrors"
+	"github.com/spf13/cobra"
+)
+
+var exportCmd = &cobra.Command{
+	Use:        "export",
+	SuggestFor: []string{"capture"},
+	Short:      "Export project assets from OpenWhisk",
+	Long:       `Exports managed project assets from OpenWhisk to manifest and function files`,
+	RunE:       ExportCmdImp,
+}
+
+var config *whisk.Config
+
+func ExportAction(actionName string, packageName string, maniyaml *parsers.YAML) error {
+
+	pkg := maniyaml.Packages[packageName]
+	if pkg.Actions == nil {
+		pkg.Actions = make(map[string]parsers.Action)
+		maniyaml.Packages[packageName] = pkg
+	}
+
+	wskAction, _, err := client.Actions.Get(actionName)
+	if err != nil {
+		return err
+	}
+	if wskAction.Exec.Kind == "sequence" {
+		seq := new(parsers.Sequence)
+		for _, component := range wskAction.Exec.Components {
+			// must ommit namespace from seq component name
+			ExportAction(strings.SplitN(component, "/", 3)[2], packageName, maniyaml)
+			slices := strings.Split(component, "/")
+
+			// save in the seq list only action names
+			if len(seq.Actions) > 0 {
+				seq.Actions += ","
+			}
+
+			seq.Actions += slices[len(slices)-1]
+		}
+
+		pkg = maniyaml.Packages[packageName]
+		if pkg.Sequences == nil {
+			pkg.Sequences = make(map[string]parsers.Sequence)
+		}
+
+		pkg.Sequences[wskAction.Name] = *seq
+	} else {
+		parsedAction := *maniyaml.ComposeParsersAction(*wskAction)
+
+		// get the action file extension according to action kind (e.g. js for nodejs)
+		ext := utils.FileRuntimeExtensionsMap[wskAction.Exec.Kind]
+
+		manifestDir := filepath.Dir(utils.Flags.ManifestPath)
+		functionFile := filepath.Join(manifestDir, wskAction.Name) + "." + ext
+		parsedAction.Function = functionFile
+
+		f, err := os.Create(functionFile)
+		if err != nil {
+			return wskderrors.NewFileReadError(functionFile, err.Error())
+		}
+
+		defer f.Close()
+
+		// store action function in the filesystem next to the manifest.yml
+		// TODO: consider to name files by namespace + action to make function file names uniqueue
+		f.Write([]byte(*wskAction.Exec.Code))
+		pkg.Actions[wskAction.Name] = parsedAction
+	}
+
+	maniyaml.Packages[packageName] = pkg
+	return nil
+}
+
+func ExportCmdImp(cmd *cobra.Command, args []string) error {
+
+	projectName := utils.Flags.ProjectPath
+	maniyaml := &parsers.YAML{}
+	maniyaml.Project.Name = projectName
+
+	config, _ = deployers.NewWhiskConfig(wskpropsPath, utils.Flags.DeploymentPath, utils.Flags.ManifestPath, false)
+	client, _ = deployers.CreateNewClient(config)
+
+	// Init supported runtimes and action files extensions maps
+	setSupportedRuntimes(config.Host)
+
+	// Get the list of packages in your namespace
+	packages, _, err := client.Packages.List(&whisk.PackageListOptions{})
+	if err != nil {
+		return err
+	}
+
+	// iterate over each package to find managed annotations
+	// check if "managed" annotation is attached to a package
+	// add to export when managed project name matches with the
+	// specified project name
+	for _, pkg := range packages {
+		if a := pkg.Annotations.GetValue(utils.MANAGED); a != nil {
+			// decode the JSON blob and retrieve __OW_PROJECT_NAME
+			pa := a.(map[string]interface{})
+
+			// we have found a package which is part of the current project
+			if pa[utils.OW_PROJECT_NAME] == projectName {
+
+				if maniyaml.Packages == nil {
+					maniyaml.Packages = make(map[string]parsers.Package)
+				}
+
+				maniyaml.Packages[pkg.Name] = *maniyaml.ComposeParsersPackage(pkg)
+				// TODO: throw if there more than single package managed by project
+				// currently will be a mess because triggers and rules managed under packages
+				// instead of the top level (similar to OW model)
+				if len(maniyaml.Packages) > 1 {
+					return errors.New("currently can't work with more than one package managed by one project")
+				}
+
+				// perform the similar check on the list of actions from this package
+				// get a list of actions in your namespace
+				actions, _, err := client.Actions.List(pkg.Name, &whisk.ActionListOptions{})
+				if err != nil {
+					return err
+				}
+
+				// iterate over list of managed package actions to find an action with managed annotations
+				// check if "managed" annotation is attached to an action
+				for _, action := range actions {
+					// TODO: consider to throw error when there unmanaged or "foreign" assets under managed package
+					// an annotation with "managed" key indicates that an action was deployed as part of managed deployment
+					// if such annotation exists, check if it belongs to the current managed deployment
+					// this action has attached managed annotations
+					if a := action.Annotations.GetValue(utils.MANAGED); a != nil {
+						aa := a.(map[string]interface{})
+						if aa[utils.OW_PROJECT_NAME] == projectName {
+							actionName := strings.Join([]string{pkg.Name, action.Name}, "/")
+							// export action to file system
+							err = ExportAction(actionName, pkg.Name, maniyaml)
+							if err != nil {
+								return err
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Get list of triggers in your namespace
+	triggers, _, err := client.Triggers.List(&whisk.TriggerListOptions{})
+	if err != nil {
+		return err
+	}
+
+	// iterate over the list of triggers to determine whether any of them part of specified managed project
+	for _, trg := range triggers {
+		// trigger has attached managed annotation
+		if a := trg.Annotations.GetValue(utils.MANAGED); a != nil {
+			// decode the JSON blob and retrieve __OW_PROJECT_NAME
+			ta := a.(map[string]interface{})
+			if ta[utils.OW_PROJECT_NAME] == projectName {
+				for _, pkg := range maniyaml.Packages {
+					if pkg.Namespace == trg.Namespace {
+						if pkg.Triggers == nil {
+							pkg.Triggers = make(map[string]parsers.Trigger)
+						}
+
+						// export trigger to manifest
+						pkg.Triggers[trg.Name] = *maniyaml.ComposeParsersTrigger(trg)
+					}
+				}
+			}
+		}
+	}
+
+	// Get list of rules from OW
+	rules, _, err := client.Rules.List(&whisk.RuleListOptions{})
+	if err != nil {
+		return err
+	}
+
+	// TODO: can be simplifyed once OW permits to add annotation to rules
+	// iterate over the list of rules to determine whether any of them is part of
+	// managed trigger -> action set for specified managed project. if yes, add to manifest
+	for _, rl := range rules {
+		// get rule from OW
+		rule, _, _ := client.Rules.Get(rl.Name)
+		ruleAction := rule.Action.(map[string]interface{})["name"].(string)
+		ruleTrigger := rule.Trigger.(map[string]interface{})["name"].(string)
+
+		// can be simplified once rules moved to top level next to triggers
+		for _, pkg := range maniyaml.Packages {
+			if pkg.Namespace == rule.Namespace {
+				// iterate over all managed actions  in manifest
+				for _, action := range pkg.Actions {
+					if action.Name == ruleAction {
+						for _, trigger := range pkg.Triggers {
+							// check that managed action and trigger equals to rule action and trigger
+							if ruleTrigger == trigger.Name && trigger.Namespace == rule.Namespace {
+								if pkg.Rules == nil {
+									pkg.Rules = make(map[string]parsers.Rule)
+								}
+
+								// export rule to manifest
+								pkg.Rules[rule.Name] = *maniyaml.ComposeParsersRule(rl)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	parsers.Write(maniyaml, utils.Flags.ManifestPath)
+	fmt.Println("Manifest exported to: " + utils.Flags.ManifestPath)
+
+	return nil
+}
+
+func init() {
+	RootCmd.AddCommand(exportCmd)
+	exportCmd.Flags().StringVarP(&utils.Flags.ProjectPath, "pathpath", "p", ".", "name of the managed project")
+	exportCmd.Flags().StringVarP(&utils.Flags.ManifestPath, "manifest", "m", "", "path to manifest file to save exported data")
+}

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -208,7 +208,7 @@ func ExportCmdImp(cmd *cobra.Command, args []string) error {
 			if ta[utils.OW_PROJECT_NAME] == projectName {
 
 				//				for i := 0; i < len(maniyaml.Packages); i++ {
-				for pkgName, _ := range maniyaml.Packages {
+				for pkgName := range maniyaml.Packages {
 					if maniyaml.Packages[pkgName].Namespace == trg.Namespace {
 						if maniyaml.Packages[pkgName].Triggers == nil {
 							pkg := maniyaml.Packages[pkgName]
@@ -240,7 +240,7 @@ func ExportCmdImp(cmd *cobra.Command, args []string) error {
 		ruleTrigger := wskRule.Trigger.(map[string]interface{})["name"].(string)
 
 		// can be simplified once rules moved to top level next to triggers
-		for pkgName, _ := range maniyaml.Packages {
+		for pkgName := range maniyaml.Packages {
 			if maniyaml.Packages[pkgName].Namespace == wskRule.Namespace {
 				// iterate over all managed triggers in manifest
 				for _, trigger := range maniyaml.Packages[pkgName].Triggers {
@@ -255,7 +255,7 @@ func ExportCmdImp(cmd *cobra.Command, args []string) error {
 						}
 
 						// check that there a managed sequence action with name matching the rule action
-						for name, _ := range maniyaml.Packages[pkgName].Sequences {
+						for name := range maniyaml.Packages[pkgName].Sequences {
 							if name == ruleAction {
 								// export rule to manifest
 								ExportRule(*wskRule, pkgName, maniyaml)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,6 +21,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strings"
+
 	"github.com/apache/incubator-openwhisk-client-go/whisk"
 	"github.com/apache/incubator-openwhisk-wskdeploy/deployers"
 	"github.com/apache/incubator-openwhisk-wskdeploy/utils"
@@ -28,11 +34,6 @@ import (
 	"github.com/apache/incubator-openwhisk-wskdeploy/wski18n"
 	"github.com/apache/incubator-openwhisk-wskdeploy/wskprint"
 	"github.com/spf13/cobra"
-	"os"
-	"path"
-	"path/filepath"
-	"regexp"
-	"strings"
 )
 
 var stderr = ""
@@ -161,6 +162,7 @@ func setSupportedRuntimes(apiHost string) {
 		utils.SupportedRunTimes = utils.ConvertToMap(op)
 		utils.DefaultRunTimes = utils.DefaultRuntimes(op)
 		utils.FileExtensionRuntimeKindMap = utils.FileExtensionRuntimes(op)
+		utils.FileRuntimeExtensionsMap = utils.FileRuntimeExtensions(op)
 	}
 }
 

--- a/parsers/yamlparser.go
+++ b/parsers/yamlparser.go
@@ -357,3 +357,60 @@ func (pkg *Package) GetApis() []*whisk.Api {
 	}
 	return apis
 }
+
+//********************YAML functions*************************//
+func (yaml *YAML) ComposeParsersPackage(wskpag whisk.Package) *Package {
+	pkg := new(Package)
+	pkg.Packagename = wskpag.Name
+	pkg.Namespace = wskpag.Namespace
+	pkg.Version = wskpag.Version
+
+	for _, keyval := range wskpag.Parameters {
+		param := new(Parameter)
+		param.Value = keyval.Value
+		pkg.Inputs[keyval.Key] = *param
+	}
+
+	return pkg
+}
+
+func (yaml *YAML) ComposeParsersAction(wskact whisk.Action) *Action {
+	action := new(Action)
+	action.Name = wskact.Name
+	action.Namespace = wskact.Namespace
+	action.Version = wskact.Version
+	action.Runtime = wskact.Exec.Kind
+
+	action.Inputs = make(map[string]Parameter)
+	for _, keyval := range wskact.Parameters {
+		param := new(Parameter)
+		param.Value = keyval.Value
+		action.Inputs[keyval.Key] = *param
+	}
+
+	return action
+}
+
+func (yaml *YAML) ComposeParsersTrigger(wsktrg whisk.Trigger) *Trigger {
+	trigger := new(Trigger)
+	trigger.Name = wsktrg.Name
+	trigger.Namespace = wsktrg.Namespace
+
+	for _, keyval := range wsktrg.Parameters {
+		param := new(Parameter)
+		param.Value = keyval.Value
+		trigger.Inputs[keyval.Key] = *param
+	}
+
+	return trigger
+}
+
+func (yaml *YAML) ComposeParsersRule(wskrule whisk.Rule) *Rule {
+	rule := new(Rule)
+	rule.Name = wskrule.Name
+
+	rule.Action = wskrule.Action.(map[string]interface{})["name"].(string)
+	rule.Trigger = wskrule.Trigger.(map[string]interface{})["name"].(string)
+
+	return rule
+}

--- a/utils/flags.go
+++ b/utils/flags.go
@@ -23,7 +23,6 @@ import (
 )
 
 type WskDeployFlags struct {
-	Export          string
 	WithinOpenWhisk bool   // is this running within an OpenWhisk action?
 	ApiHost         string // OpenWhisk API host
 	Auth            string // OpenWhisk API key

--- a/utils/flags.go
+++ b/utils/flags.go
@@ -23,6 +23,7 @@ import (
 )
 
 type WskDeployFlags struct {
+	Export          string
 	WithinOpenWhisk bool   // is this running within an OpenWhisk action?
 	ApiHost         string // OpenWhisk API host
 	Auth            string // OpenWhisk API key

--- a/utils/runtimes.go
+++ b/utils/runtimes.go
@@ -68,6 +68,7 @@ type OpenWhiskInfo struct {
 var FileExtensionRuntimeKindMap map[string]string
 var SupportedRunTimes map[string][]string
 var DefaultRunTimes map[string]string
+var FileRuntimeExtensionsMap map[string]string
 
 // We could get the openwhisk info from bluemix through running the command
 // `curl -k https://openwhisk.ng.bluemix.net`
@@ -160,6 +161,29 @@ func FileExtensionRuntimes(op OpenWhiskInfo) (ext map[string]string) {
 		} else if strings.Contains(k, JAVA_FILE_EXTENSION) {
 			ext[JAVA_FILE_EXTENSION] = k
 			ext[JAR_FILE_EXTENSION] = k
+		}
+	}
+	return
+}
+
+func FileRuntimeExtensions(op OpenWhiskInfo) (rte map[string]string) {
+	rte = make(map[string]string)
+
+	for k, v := range op.Runtimes {
+		for i := range v {
+			if !v[i].Deprecated {
+				if strings.Contains(k, NODEJS_FILE_EXTENSION) {
+					rte[v[i].Kind] = NODEJS_FILE_EXTENSION
+				} else if strings.Contains(k, PYTHON_FILE_EXTENSION) {
+					rte[v[i].Kind] = PYTHON_FILE_EXTENSION
+				} else if strings.Contains(k, SWIFT_FILE_EXTENSION) {
+					rte[v[i].Kind] = SWIFT_FILE_EXTENSION
+				} else if strings.Contains(k, PHP_FILE_EXTENSION) {
+					rte[v[i].Kind] = PHP_FILE_EXTENSION
+				} else if strings.Contains(k, JAVA_FILE_EXTENSION) {
+					rte[v[i].Kind] = JAVA_FILE_EXTENSION
+				}
+			}
 		}
 	}
 	return


### PR DESCRIPTION
Introducing command to export managed project into manifest file using
`wskdeploy export -p <MANAGED_PROJECT_NAME>`-m <TARGET_MANIFEST_FILENAME>
Project assets will be stored in specified manifest file and all the
actions functions code will be stored in the same directory in respective
files.
All the exported assets (packages/actions...etc) must be managed by same
project via annotations in a regular wskdeploy way.
Currently there may be an issue with multiple managed packages under same
project, as triggers and rules currently placed under packages in the
wskdeploy manifest model, instead of top level similar to OW model