### PR TITLE
upgrading go client

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -105,11 +105,11 @@
 		},
 		{
 			"ImportPath": "github.com/apache/incubator-openwhisk-client-go/whisk",
-			"Rev": "a81a9be21faae877e858c6ab9122a40419577f95"
+			"Rev": "717bc3a1638460e069e411e9a8bf0ea5c97f1efa"
 		},
 		{
 			"ImportPath": "github.com/apache/incubator-openwhisk-client-go/wski18n",
-			"Rev": "a81a9be21faae877e858c6ab9122a40419577f95"
+			"Rev": "717bc3a1638460e069e411e9a8bf0ea5c97f1efa"
 		},
 		{
 			"ImportPath": "github.com/pelletier/go-buffruneio",

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -61,7 +61,7 @@ func ExportAction(actionName string, packageName string, maniyaml *parsers.YAML)
 		maniyaml.Packages[packageName] = pkg
 	}
 
-	wskAction, _, err := client.Actions.Get(actionName)
+	wskAction, _, err := client.Actions.Get(actionName, true)
 	if err != nil {
 		return err
 	}
@@ -112,8 +112,10 @@ func ExportAction(actionName string, packageName string, maniyaml *parsers.YAML)
 		defer f.Close()
 
 		// store action function in the filesystem next to the manifest.yml
-		// TODO: consider to name files by namespace + action to make function file names uniqueue
-		f.Write([]byte(*wskAction.Exec.Code))
+		// TODO: consider to name files by namespace + action to make function file names unique
+		if wskAction.Exec.Code != nil {
+			f.Write([]byte(*wskAction.Exec.Code))
+		}
 		pkg.Actions[wskAction.Name] = parsedAction
 	}
 

--- a/deployers/servicedeployer.go
+++ b/deployers/servicedeployer.go
@@ -1331,7 +1331,7 @@ func (deployer *ServiceDeployer) deleteAction(pkgname string, action *whisk.Acti
 
 	displayPreprocessingInfo(parsers.YAML_KEY_ACTION, action.Name, false)
 
-	if _, _, ok := deployer.Client.Actions.Get(action.Name); ok == nil {
+	if _, _, ok := deployer.Client.Actions.Get(action.Name, false); ok == nil {
 		var err error
 		var response *http.Response
 		err = retry(DEFAULT_ATTEMPTS, DEFAULT_INTERVAL, func() error {


### PR DESCRIPTION
There was a change in the function signature of Get action https://github.com/apache/incubator-openwhisk-client-go/commit/72bf7128873a77d9973af0018a5ffad940b4691e

```
-func (s *ActionService) Get(actionName string) (*Action, *http.Response, error) {
 +func (s *ActionService) Get(actionName string, fetchCode bool) (*Action, *http.Response, error) {
```

`fetchCode` was added to determine whether to return function code or not on a GET call. I am updating `wskdeploy` to match this new function call. We have two places we are using this function,

(1) in case of delete an action, there is no need of getting action code and therefore passing `false`.
(2) While exporting an action, we need action source code and therefore passing `true`.