### PR TITLE
Fix the failure issue in travis 

### DIFF
--- a/tools/travis/script.sh
+++ b/tools/travis/script.sh
@@ -43,7 +43,7 @@ WHISKDIR="$HOMEDIR/openwhisk"
 cd $WHISKDIR
 ./tools/travis/setup.sh
 
-ANSIBLE_CMD="ansible-playbook -i ${ROOTDIR}/ansible/environments/local -e docker_image_prefix=openwhisk"
+ANSIBLE_CMD="ansible-playbook -i environments/local -e docker_image_prefix=openwhisk"
 
 cd $WHISKDIR/ansible
 $ANSIBLE_CMD setup.yml


### PR DESCRIPTION
This PR changes the configuration of openwhisk installation script back to use the one under openwhisk.