### PR TITLE
Updated documentation and examples to use the new packages syntax

### DIFF
--- a/docs/examples/deployment_hello_world_triggerrule_unbound.yaml
+++ b/docs/examples/deployment_hello_world_triggerrule_unbound.yaml
@@ -15,7 +15,7 @@
 #
 
 project:
-  package:
+  packages:
     hello_world_package:
       triggers:
         meetPerson:

--- a/docs/examples/manifest_hello_world.yaml
+++ b/docs/examples/manifest_hello_world.yaml
@@ -15,10 +15,10 @@
 #
 
 # Example: Basic Hello World using a NodeJS (JavaScript) action
-package:
-  name: hello_world_package
-  version: 1.0
-  license: Apache-2.0
-  actions:
-    hello_world:
-      function: src/hello.js
+packages:
+  hello_world_package:
+    version: 1.0
+    license: Apache-2.0
+    actions:
+      hello_world:
+        function: src/hello.js

--- a/docs/examples/manifest_hello_world_advanced_parms.yaml
+++ b/docs/examples/manifest_hello_world_advanced_parms.yaml
@@ -15,34 +15,34 @@
 #
 
 # Example: input and output parameters with advanced fields
-package:
-  name: hello_world_package
-  version: 1.0
-  license: Apache-2.0
-  actions:
-    hello_world_advanced_parms:
-      function: src/hello_plus.js
-      inputs:
-        name:
-          type: string
-          description: name of person
-          default: unknown person
-        place:
-          type: string
-          description: location of person
-          value: the Shire
-        children:
-          type: integer
-          description: Number of children
-          default: 0
-        height:
-          type: float
-          description: height in meters
-          default: 0.0
-      outputs:
-        greeting:
-          type: string
-          description: greeting string
-        details:
-          type: string
-          description: detailed information about the person
+packages:
+  hello_world_package:
+    version: 1.0
+    license: Apache-2.0
+    actions:
+      hello_world_advanced_parms:
+        function: src/hello_plus.js
+        inputs:
+          name:
+            type: string
+            description: name of person
+            default: unknown person
+          place:
+            type: string
+            description: location of person
+            value: the Shire
+          children:
+            type: integer
+            description: Number of children
+            default: 0
+          height:
+            type: float
+            description: height in meters
+            default: 0.0
+        outputs:
+          greeting:
+            type: string
+            description: greeting string
+          details:
+            type: string
+            description: detailed information about the person

--- a/docs/examples/manifest_hello_world_env_var_parms.yaml
+++ b/docs/examples/manifest_hello_world_env_var_parms.yaml
@@ -15,16 +15,16 @@
 #
 
 # Example: “Hello world” with input values set from environment variables
-package:
-  name: hello_world_package
-  version: 1.0
-  license: Apache-2.0
-  actions:
-    hello_world_env_var_parms:
-      function: src/hello.js
-      inputs:
-        name: $FIRSTNAME
-        place:
-          value: ${TOWN}, ${COUNTRY}
-      outputs:
-        greeting: string
+packages:
+  hello_world_package:
+    version: 1.0
+    license: Apache-2.0
+    actions:
+      hello_world_env_var_parms:
+        function: src/hello.js
+        inputs:
+          name: $FIRSTNAME
+          place:
+            value: ${TOWN}, ${COUNTRY}
+        outputs:
+          greeting: string

--- a/docs/examples/manifest_hello_world_fixed_parms.yaml
+++ b/docs/examples/manifest_hello_world_fixed_parms.yaml
@@ -15,13 +15,13 @@
 #
 
 # Example: “Hello world” with fixed input values for ‘name’ and ‘place’
-package:
-  name: hello_world_package
-  version: 1.0
-  license: Apache-2.0
-  actions:
-    hello_world_fixed_parms:
-      function: src/hello.js
-      inputs:
-        name: Sam
-        place: the Shire
+packages:
+  hello_world_package:
+    version: 1.0
+    license: Apache-2.0
+    actions:
+      hello_world_fixed_parms:
+        function: src/hello.js
+        inputs:
+          name: Sam
+          place: the Shire

--- a/docs/examples/manifest_hello_world_runtime.yaml
+++ b/docs/examples/manifest_hello_world_runtime.yaml
@@ -15,11 +15,11 @@
 #
 
 # Example: explicit selection of the NodeJS version 6 runtime
-package:
-  name: hello_world_package
-  version: 1.0
-  license: Apache-2.0
-  actions:
-    hello_world_runtime:
-      function: src/hello.js
-      runtime: nodejs@6
+packages:
+  hello_world_package:
+    version: 1.0
+    license: Apache-2.0
+    actions:
+      hello_world_runtime:
+        function: src/hello.js
+        runtime: nodejs@6

--- a/docs/examples/manifest_hello_world_triggerrule.yaml
+++ b/docs/examples/manifest_hello_world_triggerrule.yaml
@@ -14,31 +14,31 @@
 # specific language governing permissions and limitations under the License.
 #
 
-package:
-  name: hello_world_package
-  version: 1.0
-  license: Apache-2.0
-  actions:
-    hello_world_triggerrule:
-      function: src/hello_plus.js
-      inputs:
-        name: string
-        place: string
-        children: integer
-        height: float
-      outputs:
-        greeting: string
-        details: string
+packages:
+  hello_world_package:
+    version: 1.0
+    license: Apache-2.0
+    actions:
+      hello_world_triggerrule:
+        function: src/hello_plus.js
+        inputs:
+          name: string
+          place: string
+          children: integer
+          height: float
+        outputs:
+          greeting: string
+          details: string
 
-  triggers:
-    meetPerson:
-      inputs:
-        name: Sam
-        place: the Shire
-        children: 13
-        height: 1.2
+    triggers:
+      meetPerson:
+        inputs:
+          name: Sam
+          place: the Shire
+          children: 13
+          height: 1.2
 
-  rules:
-    meetPersonRule:
-      trigger: meetPerson
-      action: hello_world_triggerrule
+    rules:
+      meetPersonRule:
+        trigger: meetPerson
+        action: hello_world_triggerrule

--- a/docs/examples/manifest_hello_world_triggerrule_unbound.yaml
+++ b/docs/examples/manifest_hello_world_triggerrule_unbound.yaml
@@ -14,31 +14,31 @@
 # specific language governing permissions and limitations under the License.
 #
 
-package:
-  name: hello_world_package
-  version: 1.0
-  license: Apache-2.0
-  actions:
-    hello_world_triggerrule:
-      function: src/hello_plus.js
-      inputs:
-        name: string
-        place: string
-        children: integer
-        height: float
-      outputs:
-        greeting: string
-        details: string
+packages:
+  hello_world_package:
+    version: 1.0
+    license: Apache-2.0
+    actions:
+      hello_world_triggerrule:
+        function: src/hello_plus.js
+        inputs:
+          name: string
+          place: string
+          children: integer
+          height: float
+        outputs:
+          greeting: string
+          details: string
 
-  triggers:
-    meetPerson:
-      inputs:
-        name: string
-        place: string
-        children: integer
-        height: float
+    triggers:
+      meetPerson:
+        inputs:
+          name: string
+          place: string
+          children: integer
+          height: float
 
-  rules:
-    meetPersonRule:
-      trigger: meetPerson
-      action: hello_world_triggerrule
+    rules:
+      meetPersonRule:
+        trigger: meetPerson
+        action: hello_world_triggerrule

--- a/docs/examples/manifest_hello_world_typed_parms.yaml
+++ b/docs/examples/manifest_hello_world_typed_parms.yaml
@@ -15,18 +15,18 @@
 #
 
 # Example: “Hello world” with typed input and output parameter declarations
-package:
-  name: hello_world_package
-  version: 1.0
-  license: Apache-2.0
-  actions:
-    hello_world_typed_parms:
-      function: src/hello_plus.js
-      inputs:
-        name: string
-        place: string
-        children: integer
-        height: float
-      outputs:
-        greeting: string
-        details: string
+packages:
+  hello_world_package:
+    version: 1.0
+    license: Apache-2.0
+    actions:
+      hello_world_typed_parms:
+        function: src/hello_plus.js
+        inputs:
+          name: string
+          place: string
+          children: integer
+          height: float
+        outputs:
+          greeting: string
+          details: string

--- a/docs/examples/manifest_sequence_basic.yaml
+++ b/docs/examples/manifest_sequence_basic.yaml
@@ -15,38 +15,38 @@
 #
 
 # Example: processing data in a sequence
-package:
-  name: fellowship_package
-  version: 1.0
-  license: Apache-2.0
-  actions:
-    member_join:
-      function: src/member_join.js
-      inputs:
-        name:
-          type: string
-          description: name of person
-          default: unknown
-        place:
-          type: string
-          description: location of person
-          default: unknown
-        job:
-          type: string
-          description: current occupation
-          default: 0
-      outputs:
-        member:
-          type: json
-          description: member record
-    member_process:
-      function: src/member_process.js
-      inputs:
-        member: {}
-    member_equip:
-      function: src/member_equip.js
-      inputs:
-        member: {}
-  sequences:
-    fellowship_membership:
-      actions: member_join, member_process, member_equip
+packages:
+  fellowship_package:
+    version: 1.0
+    license: Apache-2.0
+    actions:
+      member_join:
+        function: src/member_join.js
+        inputs:
+          name:
+            type: string
+            description: name of person
+            default: unknown
+          place:
+            type: string
+            description: location of person
+            default: unknown
+          job:
+            type: string
+            description: current occupation
+            default: 0
+        outputs:
+          member:
+            type: json
+            description: member record
+      member_process:
+        function: src/member_process.js
+        inputs:
+          member: {}
+      member_equip:
+        function: src/member_equip.js
+        inputs:
+          member: {}
+    sequences:
+      fellowship_membership:
+        actions: member_join, member_process, member_equip

--- a/docs/wskdeploy_action_advanced_parms.md
+++ b/docs/wskdeploy_action_advanced_parms.md
@@ -30,37 +30,37 @@ If we want to do more than declare the type (i.e., ‘string’, ‘integer’, 
 
 #### _Example: input and output parameters with explicit types and descriptions_
 ```yaml
-package:
-  name: hello_world_package
-  ... # Package keys omitted for brevity
-  actions:
-    hello_world_advanced_parms:
-      function: src/hello_plus.js
-      runtime: nodejs@6
-      inputs:
-        name:
-          type: string
-          description: name of person
-          default: unknown person
-        place:
-          type: string
-          description: location of person
-          value: the Shire
-        children:
-          type: integer
-          description: Number of children
-          default: 0
-        height:
-          type: float
-          description: height in meters
-          default: 0.0
-      outputs:
-        greeting:
-          type: string
-          description: greeting string
-        details:
-          type: string
-          description: detailed information about the person
+packages:
+  hello_world_package:
+    ... # Package keys omitted for brevity
+    actions:
+      hello_world_advanced_parms:
+        function: src/hello_plus.js
+        runtime: nodejs@6
+        inputs:
+          name:
+            type: string
+            description: name of person
+            default: unknown person
+          place:
+            type: string
+            description: location of person
+            value: the Shire
+          children:
+            type: integer
+            description: Number of children
+            default: 0
+          height:
+            type: float
+            description: height in meters
+            default: 0.0
+        outputs:
+          greeting:
+            type: string
+            description: greeting string
+          details:
+            type: string
+            description: detailed information about the person
 ```
 
 ### Deploying

--- a/docs/wskdeploy_action_env_var_parms.md
+++ b/docs/wskdeploy_action_env_var_parms.md
@@ -31,16 +31,16 @@ It shows how to:
 ### Manifest File
 #### _Example: “Hello world” with input values set from environment variables_
 ```yaml
-package:
-  name: hello_world_package
-  version: 1.0
-  license: Apache-2.0
-  actions:
-    hello_world_env_var_parms:
-      function: src/hello.js
-      inputs:
-        name: $FIRSTNAME
-        place: ${TOWN}, ${COUNTRY}
+packages:
+  hello_world_package:
+    version: 1.0
+    license: Apache-2.0
+    actions:
+      hello_world_env_var_parms:
+        function: src/hello.js
+        inputs:
+          name: $FIRSTNAME
+          place: ${TOWN}, ${COUNTRY}
 ```
 
 ### Deploying

--- a/docs/wskdeploy_action_fixed_parms.md
+++ b/docs/wskdeploy_action_fixed_parms.md
@@ -29,16 +29,16 @@ It shows how to:
 ### Manifest File
 #### _Example: “Hello world” with fixed input values for ‘name’ and ‘place’_
 ```yaml
-package:
-  name: hello_world_package
-  version: 1.0
-  license: Apache-2.0
-  actions:
-    hello_world_fixed_parms:
-      function: src/hello.js
-      inputs:
-        name: Sam
-        place: the Shire
+packages:
+  hello_world_package:
+    version: 1.0
+    license: Apache-2.0
+    actions:
+      hello_world_fixed_parms:
+        function: src/hello.js
+        inputs:
+          name: Sam
+          place: the Shire
 ```
 
 ### Deploying

--- a/docs/wskdeploy_action_helloworld.md
+++ b/docs/wskdeploy_action_helloworld.md
@@ -29,13 +29,13 @@ It shows how to:
 ### Manifest file
 #### _Example: “Hello world” using a NodeJS (JavaScript) action_
 ```yaml
-package:
-  name: hello_world_package
-  version: 1.0
-  license: Apache-2.0
-  actions:
-    hello_world:
-      function: src/hello.js
+packages:
+  hello_world_package:
+    version: 1.0
+    license: Apache-2.0
+    actions:
+      hello_world:
+        function: src/hello.js
 ```
 
 where "hello.js", within the package-relative subdirectory named ‘src’, contains the following JavaScript code:

--- a/docs/wskdeploy_action_runtime.md
+++ b/docs/wskdeploy_action_runtime.md
@@ -30,14 +30,14 @@ This example shows how to:
 ### Manifest file
 #### _Example: explicit selection of the NodeJS version 6 runtime_
 ```yaml
-package:
-  name: hello_world_package
-  version: 1.0
-  license: Apache-2.0
-  actions:
-    hello_world_runtime:
-      function: src/hello.js
-      runtime: nodejs@6
+packages:
+  hello_world_package:
+    version: 1.0
+    license: Apache-2.0
+    actions:
+      hello_world_runtime:
+        function: src/hello.js
+        runtime: nodejs@6
 ```
 
 ### Deploying

--- a/docs/wskdeploy_action_typed_parms.md
+++ b/docs/wskdeploy_action_typed_parms.md
@@ -32,20 +32,20 @@ It shows how to:
 ### Manifest File
 #### _Example: 'Hello world' with typed input and output parameter declarations_
 ```yaml
-package:
-  name: hello_world_package
-  ... # Package keys omitted for brevity
-  actions:
-    hello_world_typed_parms:
-      function: src/hello_plus.js
-      inputs:
-        name: string
-        place: string
-        children: integer
-        height: float
-      outputs:
-        greeting: string
-        details: string
+packages:
+  hello_world_package:
+    ... # Package keys omitted for brevity
+    actions:
+      hello_world_typed_parms:
+        function: src/hello_plus.js
+        inputs:
+          name: string
+          place: string
+          children: integer
+          height: float
+        outputs:
+          greeting: string
+          details: string
 ```
 where the function '```hello_plus.js```', within the package-relative subdirectory named ‘```src```’, is updated to use the new parameters:
 ```javascript


### PR DESCRIPTION
Should fix #826 

Updated the syntax from:

```yaml
package:
  name: package_name
  version 1.0
...
```

to:

```yaml
packages:
  package_name:
    version: 1.0
...
```
in all docs and example files. I'm not sure about the file that starts `project:` so this may need adjusting too.