### PR TITLE
Partial fix for issue #847

### DIFF
--- a/docs/examples/manifest_hello_world_apigateway_sequence.yml
+++ b/docs/examples/manifest_hello_world_apigateway_sequence.yml
@@ -1,0 +1,35 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for additional
+# information regarding copyright ownership.  The ASF licenses this file to you
+# under the Apache License, Version 2.0 (the # "License"); you may not use this
+# file except in compliance with the License.  You may obtain a copy of the License
+# at:
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+# Example: Basic Hello World action with API
+packages:
+  hello_world_package:
+    version: 1.0
+    license: Apache-2.0
+    actions:
+      hello_basic:
+        function: src/hello.js
+      hello_goodday:
+        function: src/hello_goodday.js
+    sequences:
+      hello_world:
+        actions: hello_basic, hello_goodday
+        web: true
+    apis:
+      hello-world:
+        hello:
+          world:
+            hello_world: GET

--- a/docs/examples/src/hello_goodday.js
+++ b/docs/examples/src/hello_goodday.js
@@ -1,0 +1,33 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor
+// license agreements; and to You under the Apache License, Version 2.0.
+
+/*
+ * This action is meant to capture the output from the basic Hello, world
+ * action and improve the greeting. It expects params to contain a greeting
+ * and just adds more to it.
+ */
+function main(params) {
+    msg = params.greeting + ", have a good day!";
+    return { greeting:  msg };
+}

--- a/docs/programming_guide.md
+++ b/docs/programming_guide.md
@@ -56,6 +56,7 @@ Each example shows the "code", that is the Package Manifest, Deployment file and
   - [Binding parameters in a Deployment file](wskdeploy_triggerrule_trigger_bindings.md#triggers-and-rules) - using a deployment file to bind values to a Trigger’s parameters and applying them to a compatible manifest file.
 - API Gateway examples
   - [The "Hello World" API Gateway](wskdeploy_apigateway_helloworld.md#api-gateway) - deploy a "hello world" JavaScript function with associated HTTP API.
+  - [API Gateway sequence](wskdeploy_apigateway_sequence.md#api-gateway-sequence) - deploy JavaScript sequence with associated HTTP API.
 
 ---
 <!--

--- a/docs/wskdeploy_apigateway_sequence.md
+++ b/docs/wskdeploy_apigateway_sequence.md
@@ -16,27 +16,32 @@
 #
 -->
 
-# API Gateway
+# API Gateway sequence
 
-## The "Hello World" API
+## Sequencing actions
 
-This example builds on the ["Hello World" Action](wskdeploy_action_helloworld.md#actions) example by adding an API definition on top of that action so that I can be queried via an HTTP call.
+This example builds on the ["Hello World" API Gateway](wskdeploy_apigateway_helloworld.md#api-gateway) example by combining multiple actions in a sequence to create a complex result and making this sequence available through the API Gateway.
 
 It shows how to:
-- update the Action named ‘hello_world’ to expose it to the gateway.
-- specify the API's endpoint that will trigger the action.
+- create a sequence that chains multiple actions.
+- export the sequence via the gateway.
 
 ### Manifest file
-#### _Example: “Hello world” action with API_
+#### _Example: “Hello world” sequence with API_
 ```yaml
 packages:
   hello_world_package:
     version: 1.0
     license: Apache-2.0
     actions:
-      hello_world:
+      hello_basic:
         function: src/hello.js
-        web-export: true
+      hello_goodday:
+        function: src/hello_goodday.js
+    sequences:
+      hello_world:
+        actions: hello_basic, hello_goodday
+        web: true
     apis:
       hello-world:
         hello:
@@ -45,17 +50,16 @@ packages:
 ```
 
 There are two key changes to this file:
-- the `hello_world` action now has the `web-export` flag set to `true`.
-- a new `apis` block has been created.
-
-The `apis` block contains a number of groups of API endpoint. Each endpoint is then defined by the hierarchy. In this case, we are creating the `hello/world` endpoint. The leaf in the structure specifies the action to trigger when the given HTTP verb is sent to that endpoint, in this case, when the HTTP verb `GET` is used on the `hello/world` endpoint, trigger the `hello_world` action.
+- we now have two actions define and neither of them is web available.
+- we have a new sequence that is web available.
+- the `apis` block now refers to the sequence rather than the action.
 
 ### Deploying
 
-You can actually deploy the "hello world API gateway" manifest from the incubator-openwhisk-wskdeploy project directory if you have downloaded it from GitHub:
+You can actually deploy the "API Gateway sequence" manifest from the incubator-openwhisk-wskdeploy project directory if you have downloaded it from GitHub:
 
 ```sh
-$ wskdeploy -m docs/examples/manifest_hello_world_apigateway.yaml
+$ wskdeploy -m docs/examples/manifest_hello_world_apigateway_sequence.yaml
 ```
 
 ### Invoking
@@ -77,7 +81,7 @@ The invocation should return a JSON response that includes this result:
 
 ```json
 {
-    "greeting": "Hello, undefined from undefined"
+    "greeting": "Hello, undefined from undefined, have a good day!"
 }
 ```
 
@@ -89,12 +93,13 @@ $ curl <url>?name=World&place=Earth
 
 ### Discussion
 
-This "hello world" example represents the minimum valid Manifest file which includes only the required parts of the Package, Action and API descriptors.
+This example is very basic but it shows the power of OpenWhisk in creating complex processes by chaining together simple actions and making the resulting sequence available via the API Gateway. This allows you to build small modular actions rather than big bulky ones. And because OpenWhisk allows actions to be written with different programming languages, you can mix and match, for example chaining a combination of JavaScript and Python actions in the same sequence.
 
 ### Source code
 The source code for the manifest and JavaScript files can be found here:
-- [manifest_hello_world_apigateway.yaml](examples/manifest_hello_world_apigateway.yaml)
+- [manifest_hello_world_apigateway_sequence.yaml](examples/manifest_hello_world_apigateway_sequence.yaml)
 - [hello.js](examples/src/hello.js)
+- [hello_goodday.js](examples/src/hello_goodday.js)
 
 ### Specification
 For convenience, the Packages and Actions grammar can be found here:
@@ -109,9 +114,9 @@ For convenience, the Packages and Actions grammar can be found here:
 <div align="center">
 <table align="center">
   <tr>
-    <td><a href="wskdeploy_triggerrule_trigger_bindings.md#triggers-and-rules">&lt;&lt;&nbsp;previous</a></td>
+    <td><a href="wskdeploy_apigateway_helloworld.md#packages">&lt;&lt;&nbsp;previous</a></td>
     <td><a href="programming_guide.md#guided-examples">Example Index</a></td>
-    <td><a href="wskdeploy_apigateway_sequence.md#api-gateway-sequence">next&nbsp;&gt;&gt;</a></td>
+    <!--<td><a href="">next&nbsp;&gt;&gt;</a></td>-->
   </tr>
 </table>
 </div>


### PR DESCRIPTION
This example shows a simple sequence exposed via the API Gateway. It doesn't handle the `web: raw` option as I haven't got experience with this option and don't know how you would write actions that handle raw HTTP. I'd be happy to improve the example or create an additional one with a bit of help.