### PR TITLE
Adds support for api export

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -18,27 +18,27 @@
 package cmd
 
 import (
-    "encoding/base64"
-    "fmt"
-    "os"
-    "path/filepath"
-    "strings"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 
-    "github.com/apache/incubator-openwhisk-client-go/whisk"
-    "github.com/apache/incubator-openwhisk-wskdeploy/deployers"
-    "github.com/apache/incubator-openwhisk-wskdeploy/parsers"
-    "github.com/apache/incubator-openwhisk-wskdeploy/runtimes"
-    "github.com/apache/incubator-openwhisk-wskdeploy/utils"
-    "github.com/apache/incubator-openwhisk-wskdeploy/wski18n"
-    "github.com/spf13/cobra"
+	"github.com/apache/incubator-openwhisk-client-go/whisk"
+	"github.com/apache/incubator-openwhisk-wskdeploy/deployers"
+	"github.com/apache/incubator-openwhisk-wskdeploy/parsers"
+	"github.com/apache/incubator-openwhisk-wskdeploy/runtimes"
+	"github.com/apache/incubator-openwhisk-wskdeploy/utils"
+	"github.com/apache/incubator-openwhisk-wskdeploy/wski18n"
+	"github.com/spf13/cobra"
 )
 
 var exportCmd = &cobra.Command{
-    Use:        "export",
-    SuggestFor: []string{"capture"},
-    Short:      "Export project assets from OpenWhisk",
-    Long:       `Exports managed project assets from OpenWhisk to manifest and function files`,
-    RunE:       ExportCmdImp,
+	Use:        "export",
+	SuggestFor: []string{"capture"},
+	Short:      "Export project assets from OpenWhisk",
+	Long:       `Exports managed project assets from OpenWhisk to manifest and function files`,
+	RunE:       ExportCmdImp,
 }
 
 var config *whisk.Config
@@ -47,433 +47,432 @@ var client *whisk.Client
 
 func ExportAction(actionName string, packageName string, maniyaml *parsers.YAML, targetManifest string, projectName string) error {
 
-    pkg := maniyaml.Packages[packageName]
-    if pkg.Actions == nil {
-        pkg.Actions = make(map[string]parsers.Action)
-        maniyaml.Packages[packageName] = pkg
-    }
+	pkg := maniyaml.Packages[packageName]
+	if pkg.Actions == nil {
+		pkg.Actions = make(map[string]parsers.Action)
+		maniyaml.Packages[packageName] = pkg
+	}
 
-    wskAction, _, err := client.Actions.Get(actionName, true)
-    if err != nil {
-        return err
-    }
+	wskAction, _, err := client.Actions.Get(actionName, true)
+	if err != nil {
+		return err
+	}
 
-    if a := wskAction.Annotations.GetValue(utils.MANAGED); a != nil {
-        // decode the JSON blob and retrieve __OW_PROJECT_NAME
-        pa := a.(map[string]interface{})
+	if a := wskAction.Annotations.GetValue(utils.MANAGED); a != nil {
+		// decode the JSON blob and retrieve __OW_PROJECT_NAME
+		pa := a.(map[string]interface{})
 
-        // we have found a package which is part of the current project
-        if pa[utils.OW_PROJECT_NAME] != projectName {
-            return nil
-        }
-    } else {
-        return nil
-    }
+		// we have found a package which is part of the current project
+		if pa[utils.OW_PROJECT_NAME] != projectName {
+			return nil
+		}
+	} else {
+		return nil
+	}
 
-    if wskAction.Exec.Kind == "sequence" {
-        seq := new(parsers.Sequence)
-        for _, component := range wskAction.Exec.Components {
-            // must ommit namespace from seq component name
-            ExportAction(strings.SplitN(component, "/", 3)[2], packageName, maniyaml, targetManifest, projectName)
+	if wskAction.Exec.Kind == "sequence" {
+		seq := new(parsers.Sequence)
+		for _, component := range wskAction.Exec.Components {
+			// must ommit namespace from seq component name
+			ExportAction(strings.SplitN(component, "/", 3)[2], packageName, maniyaml, targetManifest, projectName)
 
-            if len(seq.Actions) > 0 {
-                seq.Actions += ","
-            }
-            // save action in the seq list as package/action
-            seq.Actions += strings.SplitN(component, "/", 3)[2]
-        }
+			if len(seq.Actions) > 0 {
+				seq.Actions += ","
+			}
+			// save action in the seq list as package/action
+			seq.Actions += strings.SplitN(component, "/", 3)[2]
+		}
 
-        pkg = maniyaml.Packages[packageName]
-        if pkg.Sequences == nil {
-            pkg.Sequences = make(map[string]parsers.Sequence)
-        }
+		pkg = maniyaml.Packages[packageName]
+		if pkg.Sequences == nil {
+			pkg.Sequences = make(map[string]parsers.Sequence)
+		}
 
-        pkg.Sequences[wskAction.Name] = *seq
-    } else {
-        parsedAction := *maniyaml.ComposeParsersAction(*wskAction)
-        manifestDir := filepath.Dir(targetManifest)
+		pkg.Sequences[wskAction.Name] = *seq
+	} else {
+		parsedAction := *maniyaml.ComposeParsersAction(*wskAction)
+		manifestDir := filepath.Dir(targetManifest)
 
-        // store function file under action package name subdirectory in the specified manifest folder
-        functionDir := filepath.Join(manifestDir, packageName)
+		// store function file under action package name subdirectory in the specified manifest folder
+		functionDir := filepath.Join(manifestDir, packageName)
 
-        // save the code in file
-        filename, err := saveCode(*wskAction, functionDir)
-        if err != nil {
-            return err
-        }
+		// save the code in file
+		filename, err := saveCode(*wskAction, functionDir)
+		if err != nil {
+			return err
+		}
 
-        if filename != "" {
-            // store function in manifest if action has code section
-            parsedAction.Function = packageName + "/" + filename
-        }
+		if filename != "" {
+			// store function in manifest if action has code section
+			parsedAction.Function = packageName + "/" + filename
+		}
 
-        pkg.Actions[wskAction.Name] = parsedAction
-    }
+		pkg.Actions[wskAction.Name] = parsedAction
+	}
 
-    maniyaml.Packages[packageName] = pkg
-    return nil
+	maniyaml.Packages[packageName] = pkg
+	return nil
 }
 
 func exportProject(projectName string, targetManifest string) error {
-    maniyaml := &parsers.YAML{}
-    maniyaml.Project.Name = projectName
+	maniyaml := &parsers.YAML{}
+	maniyaml.Project.Name = projectName
 
-    // Get the list of packages in your namespace
-    packages, _, err := client.Packages.List(&whisk.PackageListOptions{})
-    if err != nil {
-        return err
-    }
+	// Get the list of packages in your namespace
+	packages, _, err := client.Packages.List(&whisk.PackageListOptions{})
+	if err != nil {
+		return err
+	}
 
-    var bindings = make(map[string]whisk.Binding)
+	var bindings = make(map[string]whisk.Binding)
 
-    // iterate over each package to find managed annotations
-    // check if "managed" annotation is attached to a package
-    // add to export when managed project name matches with the
-    // specified project name
-    for _, pkg := range packages {
-        if a := pkg.Annotations.GetValue(utils.MANAGED); a != nil {
-            // decode the JSON blob and retrieve __OW_PROJECT_NAME
-            pa := a.(map[string]interface{})
+	// iterate over each package to find managed annotations
+	// check if "managed" annotation is attached to a package
+	// add to export when managed project name matches with the
+	// specified project name
+	for _, pkg := range packages {
+		if a := pkg.Annotations.GetValue(utils.MANAGED); a != nil {
+			// decode the JSON blob and retrieve __OW_PROJECT_NAME
+			pa := a.(map[string]interface{})
 
-            // we have found a package which is part of the current project
-            if pa[utils.OW_PROJECT_NAME] == projectName {
+			// we have found a package which is part of the current project
+			if pa[utils.OW_PROJECT_NAME] == projectName {
 
-                // check if the package is dependency
-                if pkg.Annotations.GetValue(wski18n.BINDING) != nil {
-                    bindings[pkg.Name] = *pkg.Binding
-                    continue
-                }
+				// check if the package is dependency
+				if pkg.Annotations.GetValue(wski18n.BINDING) != nil {
+					bindings[pkg.Name] = *pkg.Binding
+					continue
+				}
 
-                if maniyaml.Packages == nil {
-                    maniyaml.Packages = make(map[string]parsers.Package)
-                }
+				if maniyaml.Packages == nil {
+					maniyaml.Packages = make(map[string]parsers.Package)
+				}
 
-                maniyaml.Packages[pkg.Name] = *maniyaml.ComposeParsersPackage(pkg)
-                // TODO: throw if there more than single package managed by project
-                // currently will be a mess because triggers and rules managed under packages
-                // instead of the top level (similar to OW model)
-                //              if len(maniyaml.Packages) > 1 {
-                //                  return errors.New("currently can't work with more than one package managed by one project")
-                //              }
+				maniyaml.Packages[pkg.Name] = *maniyaml.ComposeParsersPackage(pkg)
+				// TODO: throw if there more than single package managed by project
+				// currently will be a mess because triggers and rules managed under packages
+				// instead of the top level (similar to OW model)
+				//              if len(maniyaml.Packages) > 1 {
+				//                  return errors.New("currently can't work with more than one package managed by one project")
+				//              }
 
-                // perform the similar check on the list of actions from this package
-                // get a list of actions in your namespace
-                actions, _, err := client.Actions.List(pkg.Name, &whisk.ActionListOptions{})
-                if err != nil {
-                    return err
-                }
+				// perform the similar check on the list of actions from this package
+				// get a list of actions in your namespace
+				actions, _, err := client.Actions.List(pkg.Name, &whisk.ActionListOptions{})
+				if err != nil {
+					return err
+				}
 
-                // iterate over list of managed package actions to find an action with managed annotations
-                // check if "managed" annotation is attached to an action
-                for _, action := range actions {
-                    // TODO: consider to throw error when there unmanaged or "foreign" assets under managed package
-                    // an annotation with "managed" key indicates that an action was deployed as part of managed deployment
-                    // if such annotation exists, check if it belongs to the current managed deployment
-                    // this action has attached managed annotations
-                    if a := action.Annotations.GetValue(utils.MANAGED); a != nil {
-                        aa := a.(map[string]interface{})
-                        if aa[utils.OW_PROJECT_NAME] == projectName {
-                            actionName := strings.Join([]string{pkg.Name, action.Name}, "/")
-                            // export action to file system
-                            err = ExportAction(actionName, pkg.Name, maniyaml, targetManifest, projectName)
-                            if err != nil {
-                                return err
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
+				// iterate over list of managed package actions to find an action with managed annotations
+				// check if "managed" annotation is attached to an action
+				for _, action := range actions {
+					// TODO: consider to throw error when there unmanaged or "foreign" assets under managed package
+					// an annotation with "managed" key indicates that an action was deployed as part of managed deployment
+					// if such annotation exists, check if it belongs to the current managed deployment
+					// this action has attached managed annotations
+					if a := action.Annotations.GetValue(utils.MANAGED); a != nil {
+						aa := a.(map[string]interface{})
+						if aa[utils.OW_PROJECT_NAME] == projectName {
+							actionName := strings.Join([]string{pkg.Name, action.Name}, "/")
+							// export action to file system
+							err = ExportAction(actionName, pkg.Name, maniyaml, targetManifest, projectName)
+							if err != nil {
+								return err
+							}
+						}
+					}
+				}
+			}
+		}
+	}
 
-    // Get list of triggers in your namespace
-    triggers, _, err := client.Triggers.List(&whisk.TriggerListOptions{})
-    if err != nil {
-        return err
-    }
+	// Get list of triggers in your namespace
+	triggers, _, err := client.Triggers.List(&whisk.TriggerListOptions{})
+	if err != nil {
+		return err
+	}
 
-    // iterate over the list of triggers to determine whether any of them part of specified managed project
-    for _, trg := range triggers {
-        // trigger has attached managed annotation
-        if a := trg.Annotations.GetValue(utils.MANAGED); a != nil {
-            // decode the JSON blob and retrieve __OW_PROJECT_NAME
-            ta := a.(map[string]interface{})
-            if ta[utils.OW_PROJECT_NAME] == projectName {
+	// iterate over the list of triggers to determine whether any of them part of specified managed project
+	for _, trg := range triggers {
+		// trigger has attached managed annotation
+		if a := trg.Annotations.GetValue(utils.MANAGED); a != nil {
+			// decode the JSON blob and retrieve __OW_PROJECT_NAME
+			ta := a.(map[string]interface{})
+			if ta[utils.OW_PROJECT_NAME] == projectName {
 
-                for pkgName := range maniyaml.Packages {
-                    if maniyaml.Packages[pkgName].Namespace == trg.Namespace {
-                        if maniyaml.Packages[pkgName].Triggers == nil {
-                            pkg := maniyaml.Packages[pkgName]
-                            pkg.Triggers = make(map[string]parsers.Trigger)
-                            maniyaml.Packages[pkgName] = pkg
-                        }
+				for pkgName := range maniyaml.Packages {
+					if maniyaml.Packages[pkgName].Namespace == trg.Namespace {
+						if maniyaml.Packages[pkgName].Triggers == nil {
+							pkg := maniyaml.Packages[pkgName]
+							pkg.Triggers = make(map[string]parsers.Trigger)
+							maniyaml.Packages[pkgName] = pkg
+						}
 
-                        // export trigger to manifest
+						// export trigger to manifest
 
-                        if feedname, isFeed := utils.IsFeedAction(&trg); isFeed {
-                            // export feed input parameters
-                            feedAction, _, _ := client.Actions.Get(feedname, true)
-                            if err != nil {
-                                return err
-                            }
+						if feedname, isFeed := utils.IsFeedAction(&trg); isFeed {
+							// export feed input parameters
+							feedAction, _, _ := client.Actions.Get(feedname, true)
+							if err != nil {
+								return err
+							}
 
-                            params := make(map[string]interface{})
-                            params["authKey"] = client.Config.AuthToken
-                            params["lifecycleEvent"] = "READ"
-                            params["triggerName"] = "/" + client.Namespace + "/" + trg.Name
-                            res, _, err := client.Actions.Invoke(feedname, params, true, true)
-                            if err != nil {
-                                return err
-                            }
-                            feedConfig := res["config"]
-                            for key, val := range feedConfig.(map[string]interface{}) {
+							params := make(map[string]interface{})
+							params["authKey"] = client.Config.AuthToken
+							params["lifecycleEvent"] = "READ"
+							params["triggerName"] = "/" + client.Namespace + "/" + trg.Name
+							res, _, err := client.Actions.Invoke(feedname, params, true, true)
+							if err != nil {
+								return err
+							}
+							feedConfig := res["config"]
+							for key, val := range feedConfig.(map[string]interface{}) {
 
-                                if i := feedAction.Parameters.FindKeyValue(key); i >= 0 {
-                                    trg.Parameters = trg.Parameters.AddOrReplace(&whisk.KeyValue{Key: key, Value: val})
-                                }
-                            }
-                        }
+								if i := feedAction.Parameters.FindKeyValue(key); i >= 0 {
+									trg.Parameters = trg.Parameters.AddOrReplace(&whisk.KeyValue{Key: key, Value: val})
+								}
+							}
+						}
 
-                        maniyaml.Packages[pkgName].Triggers[trg.Name] = *maniyaml.ComposeParsersTrigger(trg)
-                    }
-                }
-            }
-        }
-    }
+						maniyaml.Packages[pkgName].Triggers[trg.Name] = *maniyaml.ComposeParsersTrigger(trg)
+					}
+				}
+			}
+		}
+	}
 
-    // Get list of rules from OW
-    rules, _, err := client.Rules.List(&whisk.RuleListOptions{})
-    if err != nil {
-        return err
-    }
+	// Get list of rules from OW
+	rules, _, err := client.Rules.List(&whisk.RuleListOptions{})
+	if err != nil {
+		return err
+	}
 
-    // iterate over the list of rules to determine whether any of them is part of the manage dproject
-    for _, rule := range rules {
-        // get rule from OW
-        wskRule, _, _ := client.Rules.Get(rule.Name)
-        // rule has attached managed annotation
-        if a := wskRule.Annotations.GetValue(utils.MANAGED); a != nil {
-            // decode the JSON blob and retrieve __OW_PROJECT_NAME
-            ta := a.(map[string]interface{})
-            if ta[utils.OW_PROJECT_NAME] == projectName {
+	// iterate over the list of rules to determine whether any of them is part of the manage dproject
+	for _, rule := range rules {
+		// get rule from OW
+		wskRule, _, _ := client.Rules.Get(rule.Name)
+		// rule has attached managed annotation
+		if a := wskRule.Annotations.GetValue(utils.MANAGED); a != nil {
+			// decode the JSON blob and retrieve __OW_PROJECT_NAME
+			ta := a.(map[string]interface{})
+			if ta[utils.OW_PROJECT_NAME] == projectName {
 
-                for pkgName := range maniyaml.Packages {
-                    if maniyaml.Packages[pkgName].Namespace == wskRule.Namespace {
-                        if maniyaml.Packages[pkgName].Rules == nil {
-                            pkg := maniyaml.Packages[pkgName]
-                            pkg.Rules = make(map[string]parsers.Rule)
-                            maniyaml.Packages[pkgName] = pkg
-                        }
+				for pkgName := range maniyaml.Packages {
+					if maniyaml.Packages[pkgName].Namespace == wskRule.Namespace {
+						if maniyaml.Packages[pkgName].Rules == nil {
+							pkg := maniyaml.Packages[pkgName]
+							pkg.Rules = make(map[string]parsers.Rule)
+							maniyaml.Packages[pkgName] = pkg
+						}
 
-                        // export rule to manifest
-                        maniyaml.Packages[pkgName].Rules[wskRule.Name] = *maniyaml.ComposeParsersRule(*wskRule)
-                    }
-                }
-            }
-        }
+						// export rule to manifest
+						maniyaml.Packages[pkgName].Rules[wskRule.Name] = *maniyaml.ComposeParsersRule(*wskRule)
+					}
+				}
+			}
+		}
 
-    }
+	}
 
-    // List API request query parameters
-    apiListReqOptions := new(whisk.ApiListRequestOptions)
-    apiListReqOptions.SpaceGuid = strings.Split(client.Config.AuthToken, ":")[0]
-    apiListReqOptions.AccessToken = client.Config.ApigwAccessToken
+	// List API request query parameters
+	apiListReqOptions := new(whisk.ApiListRequestOptions)
+	apiListReqOptions.SpaceGuid = strings.Split(client.Config.AuthToken, ":")[0]
+	apiListReqOptions.AccessToken = client.Config.ApigwAccessToken
 
-    // Get list of APIs from OW
-    retApiList, _, err := client.Apis.List(apiListReqOptions)
-    if err != nil {
-        return err
-    }
+	// Get list of APIs from OW
+	retApiList, _, err := client.Apis.List(apiListReqOptions)
+	if err != nil {
+		return err
+	}
 
-    // iterate over the list of APIs to determine whether any of them part of the managed project
-    retApiArray := (*whisk.RetApiArray)(retApiList)
-    for _, api := range retApiArray.Apis {
+	// iterate over the list of APIs to determine whether any of them part of the managed project
+	retApiArray := (*whisk.RetApiArray)(retApiList)
+	for _, api := range retApiArray.Apis {
 
-        apiName := api.ApiValue.Swagger.Info.Title
-        apiBasePath := strings.TrimPrefix(api.ApiValue.Swagger.BasePath, "/")
+		apiName := api.ApiValue.Swagger.Info.Title
+		apiBasePath := strings.TrimPrefix(api.ApiValue.Swagger.BasePath, "/")
 
-        // run over api paths looking for one pointing to an action belonging to the given project
-        for path := range api.ApiValue.Swagger.Paths {
-            for op, opv := range api.ApiValue.Swagger.Paths[path].MakeOperationMap() {
-                if len(opv.XOpenWhisk.Package) > 0 {
-                    pkgName := opv.XOpenWhisk.Package
+		// run over api paths looking for one pointing to an action belonging to the given project
+		for path := range api.ApiValue.Swagger.Paths {
+			for op, opv := range api.ApiValue.Swagger.Paths[path].MakeOperationMap() {
+				if len(opv.XOpenWhisk.Package) > 0 {
+					pkgName := opv.XOpenWhisk.Package
 
-                    if pkg, ok := maniyaml.Packages[pkgName]; ok {
-                        if pkg.Namespace == opv.XOpenWhisk.Namespace {
+					if pkg, ok := maniyaml.Packages[pkgName]; ok {
+						if pkg.Namespace == opv.XOpenWhisk.Namespace {
 
-                            // now adding the api to the maniyaml
-                            if pkg.Apis == nil {
-                                pkg.Apis = make(map[string]map[string]map[string]map[string]parsers.APIMethodResponse)
-                            }
+							// now adding the api to the maniyaml
+							if pkg.Apis == nil {
+								pkg.Apis = make(map[string]map[string]map[string]map[string]parsers.APIMethodResponse)
+							}
 
-                            path = strings.TrimPrefix(path, "/")
+							path = strings.TrimPrefix(path, "/")
 
-                            apiMethodResponse := *new(parsers.APIMethodResponse)
-                            splitApiUrl := strings.Split(opv.XOpenWhisk.ApiUrl, ".")
-                            responseType := splitApiUrl[len(splitApiUrl)-1]
+							apiMethodResponse := *new(parsers.APIMethodResponse)
+							splitApiUrl := strings.Split(opv.XOpenWhisk.ApiUrl, ".")
+							responseType := splitApiUrl[len(splitApiUrl)-1]
 
-                            apiMethodResponse.Method = op
-                            apiMethodResponse.Response = responseType
+							apiMethodResponse.Method = op
+							apiMethodResponse.Response = responseType
 
-                            if pkgApi, ok := pkg.Apis[apiName]; ok {
-                                if pkgApiBasePath, ok := pkgApi[apiBasePath]; ok {
-                                    if _, ok := pkgApiBasePath[path]; ok {
-                                        pkg.Apis[apiName][apiBasePath][path][opv.XOpenWhisk.ActionName] = apiMethodResponse
-                                    } else {
-                                        pkg.Apis[apiName][apiBasePath][path] = map[string]parsers.APIMethodResponse{}
-                                        pkg.Apis[apiName][apiBasePath][path][opv.XOpenWhisk.ActionName] = apiMethodResponse
-                                    }
-                                } else {
-                                    pkg.Apis[apiName][apiBasePath] = map[string]map[string]parsers.APIMethodResponse{}
-                                    pkg.Apis[apiName][apiBasePath][path] = map[string]parsers.APIMethodResponse{}
-                                    pkg.Apis[apiName][apiBasePath][path][opv.XOpenWhisk.ActionName] = apiMethodResponse
-                                }
-                            } else {
-                                pkg.Apis[apiName] = map[string]map[string]map[string]parsers.APIMethodResponse{}
-                                pkg.Apis[apiName][apiBasePath] = map[string]map[string]parsers.APIMethodResponse{}
-                                pkg.Apis[apiName][apiBasePath][path] = map[string]parsers.APIMethodResponse{}
-                                pkg.Apis[apiName][apiBasePath][path][opv.XOpenWhisk.ActionName] = apiMethodResponse
-                            }
+							if pkgApi, ok := pkg.Apis[apiName]; ok {
+								if pkgApiBasePath, ok := pkgApi[apiBasePath]; ok {
+									if _, ok := pkgApiBasePath[path]; ok {
+										pkg.Apis[apiName][apiBasePath][path][opv.XOpenWhisk.ActionName] = apiMethodResponse
+									} else {
+										pkg.Apis[apiName][apiBasePath][path] = map[string]parsers.APIMethodResponse{}
+										pkg.Apis[apiName][apiBasePath][path][opv.XOpenWhisk.ActionName] = apiMethodResponse
+									}
+								} else {
+									pkg.Apis[apiName][apiBasePath] = map[string]map[string]parsers.APIMethodResponse{}
+									pkg.Apis[apiName][apiBasePath][path] = map[string]parsers.APIMethodResponse{}
+									pkg.Apis[apiName][apiBasePath][path][opv.XOpenWhisk.ActionName] = apiMethodResponse
+								}
+							} else {
+								pkg.Apis[apiName] = map[string]map[string]map[string]parsers.APIMethodResponse{}
+								pkg.Apis[apiName][apiBasePath] = map[string]map[string]parsers.APIMethodResponse{}
+								pkg.Apis[apiName][apiBasePath][path] = map[string]parsers.APIMethodResponse{}
+								pkg.Apis[apiName][apiBasePath][path][opv.XOpenWhisk.ActionName] = apiMethodResponse
+							}
 
-                            maniyaml.Packages[pkgName] = pkg
-                        }
-                    }
-                }
-            }
-        }
-    }
+							maniyaml.Packages[pkgName] = pkg
+						}
+					}
+				}
+			}
+		}
+	}
 
-    // adding dependencies to the first package
-    for pkgName := range maniyaml.Packages {
-        for bPkg, binding := range bindings {
-            if maniyaml.Packages[pkgName].Dependencies == nil {
-                pkg := maniyaml.Packages[pkgName]
-                pkg.Dependencies = make(map[string]parsers.Dependency)
-                maniyaml.Packages[pkgName] = pkg
-            }
+	// adding dependencies to the first package
+	for pkgName := range maniyaml.Packages {
+		for bPkg, binding := range bindings {
+			if maniyaml.Packages[pkgName].Dependencies == nil {
+				pkg := maniyaml.Packages[pkgName]
+				pkg.Dependencies = make(map[string]parsers.Dependency)
+				maniyaml.Packages[pkgName] = pkg
+			}
 
-            bPkgData, _, err := client.Packages.Get(bPkg)
-            if err != nil {
-                return err
-            }
+			bPkgData, _, err := client.Packages.Get(bPkg)
+			if err != nil {
+				return err
+			}
 
-            maniyaml.Packages[pkgName].Dependencies[bPkg] = *maniyaml.ComposeParsersDependency(binding, *bPkgData)
-        }
+			maniyaml.Packages[pkgName].Dependencies[bPkg] = *maniyaml.ComposeParsersDependency(binding, *bPkgData)
+		}
 
-        break
-    }
+		break
+	}
 
-    // find exported manifest parent directory
-    manifestDir := filepath.Dir(utils.Flags.ManifestPath)
-    os.MkdirAll(manifestDir, os.ModePerm)
+	// find exported manifest parent directory
+	manifestDir := filepath.Dir(utils.Flags.ManifestPath)
+	os.MkdirAll(manifestDir, os.ModePerm)
 
-    // export manifest to file
-    parsers.Write(maniyaml, targetManifest)
-    fmt.Println("Manifest exported to: " + targetManifest)
+	// export manifest to file
+	parsers.Write(maniyaml, targetManifest)
+	fmt.Println("Manifest exported to: " + targetManifest)
 
-    // create dependencies directory if not exists
-    depDir := filepath.Join(manifestDir, "dependencies")
+	// create dependencies directory if not exists
+	depDir := filepath.Join(manifestDir, "dependencies")
 
-    if len(bindings) > 0 {
-        fmt.Println("Exporting project dependencies to " + depDir)
-    }
+	if len(bindings) > 0 {
+		fmt.Println("Exporting project dependencies to " + depDir)
+	}
 
-    // now export dependencies to their own manifests
-    for _, binding := range bindings {
-        ns := client.Config.Namespace
-        client.Config.Namespace = binding.Namespace
+	// now export dependencies to their own manifests
+	for _, binding := range bindings {
+		ns := client.Config.Namespace
+		client.Config.Namespace = binding.Namespace
 
-        pkg, _, err := client.Packages.Get(binding.Name)
-        if err != nil {
-            return err
-        }
+		pkg, _, err := client.Packages.Get(binding.Name)
+		if err != nil {
+			return err
+		}
 
-        if a := pkg.Annotations.GetValue(utils.MANAGED); a != nil {
-            // decode the JSON blob and retrieve __OW_PROJECT_NAME
-            pa := a.(map[string]interface{})
+		if a := pkg.Annotations.GetValue(utils.MANAGED); a != nil {
+			// decode the JSON blob and retrieve __OW_PROJECT_NAME
+			pa := a.(map[string]interface{})
 
-            os.MkdirAll(depDir, os.ModePerm)
-            depManifestPath := filepath.Join(depDir, pa[utils.OW_PROJECT_NAME].(string)+".yaml")
+			os.MkdirAll(depDir, os.ModePerm)
+			depManifestPath := filepath.Join(depDir, pa[utils.OW_PROJECT_NAME].(string)+".yaml")
 
-            // export the whole project as dependency
-            err := exportProject(pa[utils.OW_PROJECT_NAME].(string), depManifestPath)
-            if err != nil {
-                return err
-            }
-        } else {
-            // showing warning to notify user that exported manifest dependent on unmanaged library which can't be exported
-            fmt.Println("Warning! Dependency package " + binding.Name + " currently unmanaged by any project. Unable to export this package")
-        }
-        client.Config.Namespace = ns
-    }
+			// export the whole project as dependency
+			err := exportProject(pa[utils.OW_PROJECT_NAME].(string), depManifestPath)
+			if err != nil {
+				return err
+			}
+		} else {
+			// showing warning to notify user that exported manifest dependent on unmanaged library which can't be exported
+			fmt.Println("Warning! Dependency package " + binding.Name + " currently unmanaged by any project. Unable to export this package")
+		}
+		client.Config.Namespace = ns
+	}
 
-    return nil
+	return nil
 }
 
 func ExportCmdImp(cmd *cobra.Command, args []string) error {
 
-    config, _ = deployers.NewWhiskConfig(wskpropsPath, utils.Flags.DeploymentPath, utils.Flags.ManifestPath)
-    client, _ = deployers.CreateNewClient(config)
+	config, _ = deployers.NewWhiskConfig(wskpropsPath, utils.Flags.DeploymentPath, utils.Flags.ManifestPath)
+	client, _ = deployers.CreateNewClient(config)
 
-    // Init supported runtimes and action files extensions maps
-    setSupportedRuntimes(config.Host)
+	// Init supported runtimes and action files extensions maps
+	setSupportedRuntimes(config.Host)
 
-    return exportProject(utils.Flags.ProjectName, utils.Flags.ManifestPath)
+	return exportProject(utils.Flags.ProjectName, utils.Flags.ManifestPath)
 }
 
 const (
-    JAVA_EXT = ".jar"
-    ZIP_EXT  = ".zip"
-    JAVA     = "java"
+	JAVA_EXT = ".jar"
+	ZIP_EXT  = ".zip"
+	JAVA     = "java"
 )
 
 func getBinaryKindExtension(runtime string) (extension string) {
-    switch strings.ToLower(runtime) {
-    case JAVA:
-        extension = JAVA_EXT
-    default:
-        extension = ZIP_EXT
-    }
+	switch strings.ToLower(runtime) {
+	case JAVA:
+		extension = JAVA_EXT
+	default:
+		extension = ZIP_EXT
+	}
 
-    return extension
+	return extension
 }
 
 func saveCode(action whisk.Action, directory string) (string, error) {
-    var code string
-    var runtime string
-    var exec whisk.Exec
+	var code string
+	var runtime string
+	var exec whisk.Exec
 
-    exec = *action.Exec
-    runtime = strings.Split(exec.Kind, ":")[0]
+	exec = *action.Exec
+	runtime = strings.Split(exec.Kind, ":")[0]
 
-    if exec.Code != nil {
-        code = *exec.Code
-    } else {
-        return "", nil
-    }
+	if exec.Code != nil {
+		code = *exec.Code
+	} else {
+		return "", nil
+	}
 
-    var filename = ""
-    if *exec.Binary {
-        decoded, _ := base64.StdEncoding.DecodeString(code)
-        code = string(decoded)
+	var filename = ""
+	if *exec.Binary {
+		decoded, _ := base64.StdEncoding.DecodeString(code)
+		code = string(decoded)
 
-        filename = action.Name + getBinaryKindExtension(runtime)
-    } else {
-        filename = action.Name + "." + runtimes.FileRuntimeExtensionsMap[action.Exec.Kind]
-    }
+		filename = action.Name + getBinaryKindExtension(runtime)
+	} else {
+		filename = action.Name + "." + runtimes.FileRuntimeExtensionsMap[action.Exec.Kind]
+	}
 
-    os.MkdirAll(directory, os.ModePerm)
+	os.MkdirAll(directory, os.ModePerm)
 
-    path := filepath.Join(directory, filename)
+	path := filepath.Join(directory, filename)
 
-    if err := utils.WriteFile(path, code); err != nil {
-        return "", err
-    }
+	if err := utils.WriteFile(path, code); err != nil {
+		return "", err
+	}
 
-    return filename, nil
+	return filename, nil
 }
 
 func init() {
-    RootCmd.AddCommand(exportCmd)
+	RootCmd.AddCommand(exportCmd)
 }
-

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -18,27 +18,27 @@
 package cmd
 
 import (
-	"encoding/base64"
-	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
+    "encoding/base64"
+    "fmt"
+    "os"
+    "path/filepath"
+    "strings"
 
-	"github.com/apache/incubator-openwhisk-client-go/whisk"
-	"github.com/apache/incubator-openwhisk-wskdeploy/deployers"
-	"github.com/apache/incubator-openwhisk-wskdeploy/parsers"
-	"github.com/apache/incubator-openwhisk-wskdeploy/runtimes"
-	"github.com/apache/incubator-openwhisk-wskdeploy/utils"
-	"github.com/apache/incubator-openwhisk-wskdeploy/wski18n"
-	"github.com/spf13/cobra"
+    "github.com/apache/incubator-openwhisk-client-go/whisk"
+    "github.com/apache/incubator-openwhisk-wskdeploy/deployers"
+    "github.com/apache/incubator-openwhisk-wskdeploy/parsers"
+    "github.com/apache/incubator-openwhisk-wskdeploy/runtimes"
+    "github.com/apache/incubator-openwhisk-wskdeploy/utils"
+    "github.com/apache/incubator-openwhisk-wskdeploy/wski18n"
+    "github.com/spf13/cobra"
 )
 
 var exportCmd = &cobra.Command{
-	Use:        "export",
-	SuggestFor: []string{"capture"},
-	Short:      "Export project assets from OpenWhisk",
-	Long:       `Exports managed project assets from OpenWhisk to manifest and function files`,
-	RunE:       ExportCmdImp,
+    Use:        "export",
+    SuggestFor: []string{"capture"},
+    Short:      "Export project assets from OpenWhisk",
+    Long:       `Exports managed project assets from OpenWhisk to manifest and function files`,
+    RunE:       ExportCmdImp,
 }
 
 var config *whisk.Config
@@ -47,425 +47,433 @@ var client *whisk.Client
 
 func ExportAction(actionName string, packageName string, maniyaml *parsers.YAML, targetManifest string, projectName string) error {
 
-	pkg := maniyaml.Packages[packageName]
-	if pkg.Actions == nil {
-		pkg.Actions = make(map[string]parsers.Action)
-		maniyaml.Packages[packageName] = pkg
-	}
+    pkg := maniyaml.Packages[packageName]
+    if pkg.Actions == nil {
+        pkg.Actions = make(map[string]parsers.Action)
+        maniyaml.Packages[packageName] = pkg
+    }
 
-	wskAction, _, err := client.Actions.Get(actionName, true)
-	if err != nil {
-		return err
-	}
+    wskAction, _, err := client.Actions.Get(actionName, true)
+    if err != nil {
+        return err
+    }
 
-	if a := wskAction.Annotations.GetValue(utils.MANAGED); a != nil {
-		// decode the JSON blob and retrieve __OW_PROJECT_NAME
-		pa := a.(map[string]interface{})
+    if a := wskAction.Annotations.GetValue(utils.MANAGED); a != nil {
+        // decode the JSON blob and retrieve __OW_PROJECT_NAME
+        pa := a.(map[string]interface{})
 
-		// we have found a package which is part of the current project
-		if pa[utils.OW_PROJECT_NAME] != projectName {
-			return nil
-		}
-	} else {
-		return nil
-	}
+        // we have found a package which is part of the current project
+        if pa[utils.OW_PROJECT_NAME] != projectName {
+            return nil
+        }
+    } else {
+        return nil
+    }
 
-	if wskAction.Exec.Kind == "sequence" {
-		seq := new(parsers.Sequence)
-		for _, component := range wskAction.Exec.Components {
-			// must ommit namespace from seq component name
-			ExportAction(strings.SplitN(component, "/", 3)[2], packageName, maniyaml, targetManifest, projectName)
+    if wskAction.Exec.Kind == "sequence" {
+        seq := new(parsers.Sequence)
+        for _, component := range wskAction.Exec.Components {
+            // must ommit namespace from seq component name
+            ExportAction(strings.SplitN(component, "/", 3)[2], packageName, maniyaml, targetManifest, projectName)
 
-			if len(seq.Actions) > 0 {
-				seq.Actions += ","
-			}
-			// save action in the seq list as package/action
-			seq.Actions += strings.SplitN(component, "/", 3)[2]
-		}
+            if len(seq.Actions) > 0 {
+                seq.Actions += ","
+            }
+            // save action in the seq list as package/action
+            seq.Actions += strings.SplitN(component, "/", 3)[2]
+        }
 
-		pkg = maniyaml.Packages[packageName]
-		if pkg.Sequences == nil {
-			pkg.Sequences = make(map[string]parsers.Sequence)
-		}
+        pkg = maniyaml.Packages[packageName]
+        if pkg.Sequences == nil {
+            pkg.Sequences = make(map[string]parsers.Sequence)
+        }
 
-		pkg.Sequences[wskAction.Name] = *seq
-	} else {
-		parsedAction := *maniyaml.ComposeParsersAction(*wskAction)
-		manifestDir := filepath.Dir(targetManifest)
+        pkg.Sequences[wskAction.Name] = *seq
+    } else {
+        parsedAction := *maniyaml.ComposeParsersAction(*wskAction)
+        manifestDir := filepath.Dir(targetManifest)
 
-		// store function file under action package name subdirectory in the specified manifest folder
-		functionDir := filepath.Join(manifestDir, packageName)
+        // store function file under action package name subdirectory in the specified manifest folder
+        functionDir := filepath.Join(manifestDir, packageName)
 
-		// save the code in file
-		filename, err := saveCode(*wskAction, functionDir)
-		if err != nil {
-			return err
-		}
+        // save the code in file
+        filename, err := saveCode(*wskAction, functionDir)
+        if err != nil {
+            return err
+        }
 
-		if filename != "" {
-			// store function in manifest if action has code section
-			parsedAction.Function = packageName + "/" + filename
-		}
+        if filename != "" {
+            // store function in manifest if action has code section
+            parsedAction.Function = packageName + "/" + filename
+        }
 
-		pkg.Actions[wskAction.Name] = parsedAction
-	}
+        pkg.Actions[wskAction.Name] = parsedAction
+    }
 
-	maniyaml.Packages[packageName] = pkg
-	return nil
+    maniyaml.Packages[packageName] = pkg
+    return nil
 }
 
 func exportProject(projectName string, targetManifest string) error {
-	maniyaml := &parsers.YAML{}
-	maniyaml.Project.Name = projectName
+    maniyaml := &parsers.YAML{}
+    maniyaml.Project.Name = projectName
 
-	// Get the list of packages in your namespace
-	packages, _, err := client.Packages.List(&whisk.PackageListOptions{})
-	if err != nil {
-		return err
-	}
+    // Get the list of packages in your namespace
+    packages, _, err := client.Packages.List(&whisk.PackageListOptions{})
+    if err != nil {
+        return err
+    }
 
-	var bindings = make(map[string]whisk.Binding)
+    var bindings = make(map[string]whisk.Binding)
 
-	// iterate over each package to find managed annotations
-	// check if "managed" annotation is attached to a package
-	// add to export when managed project name matches with the
-	// specified project name
-	for _, pkg := range packages {
-		if a := pkg.Annotations.GetValue(utils.MANAGED); a != nil {
-			// decode the JSON blob and retrieve __OW_PROJECT_NAME
-			pa := a.(map[string]interface{})
+    // iterate over each package to find managed annotations
+    // check if "managed" annotation is attached to a package
+    // add to export when managed project name matches with the
+    // specified project name
+    for _, pkg := range packages {
+        if a := pkg.Annotations.GetValue(utils.MANAGED); a != nil {
+            // decode the JSON blob and retrieve __OW_PROJECT_NAME
+            pa := a.(map[string]interface{})
 
-			// we have found a package which is part of the current project
-			if pa[utils.OW_PROJECT_NAME] == projectName {
+            // we have found a package which is part of the current project
+            if pa[utils.OW_PROJECT_NAME] == projectName {
 
-				// check if the package is dependency
-				if pkg.Annotations.GetValue(wski18n.BINDING) != nil {
-					bindings[pkg.Name] = *pkg.Binding
-					continue
-				}
+                // check if the package is dependency
+                if pkg.Annotations.GetValue(wski18n.BINDING) != nil {
+                    bindings[pkg.Name] = *pkg.Binding
+                    continue
+                }
 
-				if maniyaml.Packages == nil {
-					maniyaml.Packages = make(map[string]parsers.Package)
-				}
+                if maniyaml.Packages == nil {
+                    maniyaml.Packages = make(map[string]parsers.Package)
+                }
 
-				maniyaml.Packages[pkg.Name] = *maniyaml.ComposeParsersPackage(pkg)
-				// TODO: throw if there more than single package managed by project
-				// currently will be a mess because triggers and rules managed under packages
-				// instead of the top level (similar to OW model)
-				//				if len(maniyaml.Packages) > 1 {
-				//					return errors.New("currently can't work with more than one package managed by one project")
-				//				}
+                maniyaml.Packages[pkg.Name] = *maniyaml.ComposeParsersPackage(pkg)
+                // TODO: throw if there more than single package managed by project
+                // currently will be a mess because triggers and rules managed under packages
+                // instead of the top level (similar to OW model)
+                //              if len(maniyaml.Packages) > 1 {
+                //                  return errors.New("currently can't work with more than one package managed by one project")
+                //              }
 
-				// perform the similar check on the list of actions from this package
-				// get a list of actions in your namespace
-				actions, _, err := client.Actions.List(pkg.Name, &whisk.ActionListOptions{})
-				if err != nil {
-					return err
-				}
+                // perform the similar check on the list of actions from this package
+                // get a list of actions in your namespace
+                actions, _, err := client.Actions.List(pkg.Name, &whisk.ActionListOptions{})
+                if err != nil {
+                    return err
+                }
 
-				// iterate over list of managed package actions to find an action with managed annotations
-				// check if "managed" annotation is attached to an action
-				for _, action := range actions {
-					// TODO: consider to throw error when there unmanaged or "foreign" assets under managed package
-					// an annotation with "managed" key indicates that an action was deployed as part of managed deployment
-					// if such annotation exists, check if it belongs to the current managed deployment
-					// this action has attached managed annotations
-					if a := action.Annotations.GetValue(utils.MANAGED); a != nil {
-						aa := a.(map[string]interface{})
-						if aa[utils.OW_PROJECT_NAME] == projectName {
-							actionName := strings.Join([]string{pkg.Name, action.Name}, "/")
-							// export action to file system
-							err = ExportAction(actionName, pkg.Name, maniyaml, targetManifest, projectName)
-							if err != nil {
-								return err
-							}
-						}
-					}
-				}
-			}
-		}
-	}
+                // iterate over list of managed package actions to find an action with managed annotations
+                // check if "managed" annotation is attached to an action
+                for _, action := range actions {
+                    // TODO: consider to throw error when there unmanaged or "foreign" assets under managed package
+                    // an annotation with "managed" key indicates that an action was deployed as part of managed deployment
+                    // if such annotation exists, check if it belongs to the current managed deployment
+                    // this action has attached managed annotations
+                    if a := action.Annotations.GetValue(utils.MANAGED); a != nil {
+                        aa := a.(map[string]interface{})
+                        if aa[utils.OW_PROJECT_NAME] == projectName {
+                            actionName := strings.Join([]string{pkg.Name, action.Name}, "/")
+                            // export action to file system
+                            err = ExportAction(actionName, pkg.Name, maniyaml, targetManifest, projectName)
+                            if err != nil {
+                                return err
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
 
-	// Get list of triggers in your namespace
-	triggers, _, err := client.Triggers.List(&whisk.TriggerListOptions{})
-	if err != nil {
-		return err
-	}
+    // Get list of triggers in your namespace
+    triggers, _, err := client.Triggers.List(&whisk.TriggerListOptions{})
+    if err != nil {
+        return err
+    }
 
-	// iterate over the list of triggers to determine whether any of them part of specified managed project
-	for _, trg := range triggers {
-		// trigger has attached managed annotation
-		if a := trg.Annotations.GetValue(utils.MANAGED); a != nil {
-			// decode the JSON blob and retrieve __OW_PROJECT_NAME
-			ta := a.(map[string]interface{})
-			if ta[utils.OW_PROJECT_NAME] == projectName {
+    // iterate over the list of triggers to determine whether any of them part of specified managed project
+    for _, trg := range triggers {
+        // trigger has attached managed annotation
+        if a := trg.Annotations.GetValue(utils.MANAGED); a != nil {
+            // decode the JSON blob and retrieve __OW_PROJECT_NAME
+            ta := a.(map[string]interface{})
+            if ta[utils.OW_PROJECT_NAME] == projectName {
 
-				for pkgName := range maniyaml.Packages {
-					if maniyaml.Packages[pkgName].Namespace == trg.Namespace {
-						if maniyaml.Packages[pkgName].Triggers == nil {
-							pkg := maniyaml.Packages[pkgName]
-							pkg.Triggers = make(map[string]parsers.Trigger)
-							maniyaml.Packages[pkgName] = pkg
-						}
+                for pkgName := range maniyaml.Packages {
+                    if maniyaml.Packages[pkgName].Namespace == trg.Namespace {
+                        if maniyaml.Packages[pkgName].Triggers == nil {
+                            pkg := maniyaml.Packages[pkgName]
+                            pkg.Triggers = make(map[string]parsers.Trigger)
+                            maniyaml.Packages[pkgName] = pkg
+                        }
 
-						// export trigger to manifest
+                        // export trigger to manifest
 
-						if feedname, isFeed := utils.IsFeedAction(&trg); isFeed {
-							// export feed input parameters
-							feedAction, _, _ := client.Actions.Get(feedname, true)
-							if err != nil {
-								return err
-							}
+                        if feedname, isFeed := utils.IsFeedAction(&trg); isFeed {
+                            // export feed input parameters
+                            feedAction, _, _ := client.Actions.Get(feedname, true)
+                            if err != nil {
+                                return err
+                            }
 
-							params := make(map[string]interface{})
-							params["authKey"] = client.Config.AuthToken
-							params["lifecycleEvent"] = "READ"
-							params["triggerName"] = "/" + client.Namespace + "/" + trg.Name
-							res, _, err := client.Actions.Invoke(feedname, params, true, true)
-							if err != nil {
-								return err
-							}
-							feedConfig := res["config"]
-							for key, val := range feedConfig.(map[string]interface{}) {
+                            params := make(map[string]interface{})
+                            params["authKey"] = client.Config.AuthToken
+                            params["lifecycleEvent"] = "READ"
+                            params["triggerName"] = "/" + client.Namespace + "/" + trg.Name
+                            res, _, err := client.Actions.Invoke(feedname, params, true, true)
+                            if err != nil {
+                                return err
+                            }
+                            feedConfig := res["config"]
+                            for key, val := range feedConfig.(map[string]interface{}) {
 
-								if i := feedAction.Parameters.FindKeyValue(key); i >= 0 {
-									trg.Parameters = trg.Parameters.AddOrReplace(&whisk.KeyValue{Key: key, Value: val})
-								}
-							}
-						}
+                                if i := feedAction.Parameters.FindKeyValue(key); i >= 0 {
+                                    trg.Parameters = trg.Parameters.AddOrReplace(&whisk.KeyValue{Key: key, Value: val})
+                                }
+                            }
+                        }
 
-						maniyaml.Packages[pkgName].Triggers[trg.Name] = *maniyaml.ComposeParsersTrigger(trg)
-					}
-				}
-			}
-		}
-	}
+                        maniyaml.Packages[pkgName].Triggers[trg.Name] = *maniyaml.ComposeParsersTrigger(trg)
+                    }
+                }
+            }
+        }
+    }
 
-	// Get list of rules from OW
-	rules, _, err := client.Rules.List(&whisk.RuleListOptions{})
-	if err != nil {
-		return err
-	}
+    // Get list of rules from OW
+    rules, _, err := client.Rules.List(&whisk.RuleListOptions{})
+    if err != nil {
+        return err
+    }
 
-	// iterate over the list of rules to determine whether any of them is part of the manage dproject
-	for _, rule := range rules {
-		// get rule from OW
-		wskRule, _, _ := client.Rules.Get(rule.Name)
-		// rule has attached managed annotation
-		if a := wskRule.Annotations.GetValue(utils.MANAGED); a != nil {
-			// decode the JSON blob and retrieve __OW_PROJECT_NAME
-			ta := a.(map[string]interface{})
-			if ta[utils.OW_PROJECT_NAME] == projectName {
+    // iterate over the list of rules to determine whether any of them is part of the manage dproject
+    for _, rule := range rules {
+        // get rule from OW
+        wskRule, _, _ := client.Rules.Get(rule.Name)
+        // rule has attached managed annotation
+        if a := wskRule.Annotations.GetValue(utils.MANAGED); a != nil {
+            // decode the JSON blob and retrieve __OW_PROJECT_NAME
+            ta := a.(map[string]interface{})
+            if ta[utils.OW_PROJECT_NAME] == projectName {
 
-				for pkgName := range maniyaml.Packages {
-					if maniyaml.Packages[pkgName].Namespace == wskRule.Namespace {
-						if maniyaml.Packages[pkgName].Rules == nil {
-							pkg := maniyaml.Packages[pkgName]
-							pkg.Rules = make(map[string]parsers.Rule)
-							maniyaml.Packages[pkgName] = pkg
-						}
+                for pkgName := range maniyaml.Packages {
+                    if maniyaml.Packages[pkgName].Namespace == wskRule.Namespace {
+                        if maniyaml.Packages[pkgName].Rules == nil {
+                            pkg := maniyaml.Packages[pkgName]
+                            pkg.Rules = make(map[string]parsers.Rule)
+                            maniyaml.Packages[pkgName] = pkg
+                        }
 
-						// export rule to manifest
-						maniyaml.Packages[pkgName].Rules[wskRule.Name] = *maniyaml.ComposeParsersRule(*wskRule)
-					}
-				}
-			}
-		}
+                        // export rule to manifest
+                        maniyaml.Packages[pkgName].Rules[wskRule.Name] = *maniyaml.ComposeParsersRule(*wskRule)
+                    }
+                }
+            }
+        }
 
-	}
+    }
 
-	// List API request query parameters
-	apiListReqOptions := new(whisk.ApiListRequestOptions)
-	apiListReqOptions.SpaceGuid = strings.Split(client.Config.AuthToken, ":")[0]
-	apiListReqOptions.AccessToken = client.Config.ApigwAccessToken
+    // List API request query parameters
+    apiListReqOptions := new(whisk.ApiListRequestOptions)
+    apiListReqOptions.SpaceGuid = strings.Split(client.Config.AuthToken, ":")[0]
+    apiListReqOptions.AccessToken = client.Config.ApigwAccessToken
 
-	// Get list of APIs from OW
-	retApiList, _, err := client.Apis.List(apiListReqOptions)
-	if err != nil {
-		return err
-	}
+    // Get list of APIs from OW
+    retApiList, _, err := client.Apis.List(apiListReqOptions)
+    if err != nil {
+        return err
+    }
 
-	// iterate over the list of APIs to determine whether any of them part of the managed project
-	retApiArray := (*whisk.RetApiArray)(retApiList)
-	for _, api := range retApiArray.Apis {
+    // iterate over the list of APIs to determine whether any of them part of the managed project
+    retApiArray := (*whisk.RetApiArray)(retApiList)
+    for _, api := range retApiArray.Apis {
 
-		apiName := api.ApiValue.Swagger.Info.Title
-		apiBasePath := strings.TrimPrefix(api.ApiValue.Swagger.BasePath, "/")
+        apiName := api.ApiValue.Swagger.Info.Title
+        apiBasePath := strings.TrimPrefix(api.ApiValue.Swagger.BasePath, "/")
 
-		// run over api paths looking for one pointing to an action belonging to the given project
-		for path := range api.ApiValue.Swagger.Paths {
-			for op, opv := range api.ApiValue.Swagger.Paths[path].MakeOperationMap() {
-				if len(opv.XOpenWhisk.Package) > 0 {
-					pkgName := opv.XOpenWhisk.Package
+        // run over api paths looking for one pointing to an action belonging to the given project
+        for path := range api.ApiValue.Swagger.Paths {
+            for op, opv := range api.ApiValue.Swagger.Paths[path].MakeOperationMap() {
+                if len(opv.XOpenWhisk.Package) > 0 {
+                    pkgName := opv.XOpenWhisk.Package
 
-					if pkg, ok := maniyaml.Packages[pkgName]; ok {
-						if pkg.Namespace == opv.XOpenWhisk.Namespace {
+                    if pkg, ok := maniyaml.Packages[pkgName]; ok {
+                        if pkg.Namespace == opv.XOpenWhisk.Namespace {
 
-							// now adding the api to the maniyaml
-							if pkg.Apis == nil {
-								pkg.Apis = make(map[string]map[string]map[string]map[string]string)
-							}
+                            // now adding the api to the maniyaml
+                            if pkg.Apis == nil {
+                                pkg.Apis = make(map[string]map[string]map[string]map[string]parsers.APIMethodResponse)
+                            }
 
-							path = strings.TrimPrefix(path, "/")
+                            path = strings.TrimPrefix(path, "/")
 
-							if pkgApi, ok := pkg.Apis[apiName]; ok {
-								if pkgApiBasePath, ok := pkgApi[apiBasePath]; ok {
-									if _, ok := pkgApiBasePath[path]; ok {
-										pkg.Apis[apiName][apiBasePath][path][opv.OperationId] = op
-									} else {
-										pkg.Apis[apiName][apiBasePath][path] = map[string]string{}
-										pkg.Apis[apiName][apiBasePath][path][opv.OperationId] = op
-									}
-								} else {
-									pkg.Apis[apiName][apiBasePath] = map[string]map[string]string{}
-									pkg.Apis[apiName][apiBasePath][path] = map[string]string{}
-									pkg.Apis[apiName][apiBasePath][path][opv.OperationId] = op
-								}
-							} else {
-								pkg.Apis[apiName] = map[string]map[string]map[string]string{}
-								pkg.Apis[apiName][apiBasePath] = map[string]map[string]string{}
-								pkg.Apis[apiName][apiBasePath][path] = map[string]string{}
-								pkg.Apis[apiName][apiBasePath][path][opv.OperationId] = op
-							}
+                            apiMethodResponse := *new(parsers.APIMethodResponse)
+                            splitApiUrl := strings.Split(opv.XOpenWhisk.ApiUrl, ".")
+                            responseType := splitApiUrl[len(splitApiUrl)-1]
 
-							maniyaml.Packages[pkgName] = pkg
-						}
-					}
-				}
-			}
-		}
-	}
+                            apiMethodResponse.Method = op
+                            apiMethodResponse.Response = responseType
 
-	// adding dependencies to the first package
-	for pkgName := range maniyaml.Packages {
-		for bPkg, binding := range bindings {
-			if maniyaml.Packages[pkgName].Dependencies == nil {
-				pkg := maniyaml.Packages[pkgName]
-				pkg.Dependencies = make(map[string]parsers.Dependency)
-				maniyaml.Packages[pkgName] = pkg
-			}
+                            if pkgApi, ok := pkg.Apis[apiName]; ok {
+                                if pkgApiBasePath, ok := pkgApi[apiBasePath]; ok {
+                                    if _, ok := pkgApiBasePath[path]; ok {
+                                        pkg.Apis[apiName][apiBasePath][path][opv.XOpenWhisk.ActionName] = apiMethodResponse
+                                    } else {
+                                        pkg.Apis[apiName][apiBasePath][path] = map[string]parsers.APIMethodResponse{}
+                                        pkg.Apis[apiName][apiBasePath][path][opv.XOpenWhisk.ActionName] = apiMethodResponse
+                                    }
+                                } else {
+                                    pkg.Apis[apiName][apiBasePath] = map[string]map[string]parsers.APIMethodResponse{}
+                                    pkg.Apis[apiName][apiBasePath][path] = map[string]parsers.APIMethodResponse{}
+                                    pkg.Apis[apiName][apiBasePath][path][opv.XOpenWhisk.ActionName] = apiMethodResponse
+                                }
+                            } else {
+                                pkg.Apis[apiName] = map[string]map[string]map[string]parsers.APIMethodResponse{}
+                                pkg.Apis[apiName][apiBasePath] = map[string]map[string]parsers.APIMethodResponse{}
+                                pkg.Apis[apiName][apiBasePath][path] = map[string]parsers.APIMethodResponse{}
+                                pkg.Apis[apiName][apiBasePath][path][opv.XOpenWhisk.ActionName] = apiMethodResponse
+                            }
 
-			bPkgData, _, err := client.Packages.Get(bPkg)
-			if err != nil {
-				return err
-			}
+                            maniyaml.Packages[pkgName] = pkg
+                        }
+                    }
+                }
+            }
+        }
+    }
 
-			maniyaml.Packages[pkgName].Dependencies[bPkg] = *maniyaml.ComposeParsersDependency(binding, *bPkgData)
-		}
+    // adding dependencies to the first package
+    for pkgName := range maniyaml.Packages {
+        for bPkg, binding := range bindings {
+            if maniyaml.Packages[pkgName].Dependencies == nil {
+                pkg := maniyaml.Packages[pkgName]
+                pkg.Dependencies = make(map[string]parsers.Dependency)
+                maniyaml.Packages[pkgName] = pkg
+            }
 
-		break
-	}
+            bPkgData, _, err := client.Packages.Get(bPkg)
+            if err != nil {
+                return err
+            }
 
-	// find exported manifest parent directory
-	manifestDir := filepath.Dir(utils.Flags.ManifestPath)
-	os.MkdirAll(manifestDir, os.ModePerm)
+            maniyaml.Packages[pkgName].Dependencies[bPkg] = *maniyaml.ComposeParsersDependency(binding, *bPkgData)
+        }
 
-	// export manifest to file
-	parsers.Write(maniyaml, targetManifest)
-	fmt.Println("Manifest exported to: " + targetManifest)
+        break
+    }
 
-	// create dependencies directory if not exists
-	depDir := filepath.Join(manifestDir, "dependencies")
+    // find exported manifest parent directory
+    manifestDir := filepath.Dir(utils.Flags.ManifestPath)
+    os.MkdirAll(manifestDir, os.ModePerm)
 
-	if len(bindings) > 0 {
-		fmt.Println("Exporting project dependencies to " + depDir)
-	}
+    // export manifest to file
+    parsers.Write(maniyaml, targetManifest)
+    fmt.Println("Manifest exported to: " + targetManifest)
 
-	// now export dependencies to their own manifests
-	for _, binding := range bindings {
-		ns := client.Config.Namespace
-		client.Config.Namespace = binding.Namespace
+    // create dependencies directory if not exists
+    depDir := filepath.Join(manifestDir, "dependencies")
 
-		pkg, _, err := client.Packages.Get(binding.Name)
-		if err != nil {
-			return err
-		}
+    if len(bindings) > 0 {
+        fmt.Println("Exporting project dependencies to " + depDir)
+    }
 
-		if a := pkg.Annotations.GetValue(utils.MANAGED); a != nil {
-			// decode the JSON blob and retrieve __OW_PROJECT_NAME
-			pa := a.(map[string]interface{})
+    // now export dependencies to their own manifests
+    for _, binding := range bindings {
+        ns := client.Config.Namespace
+        client.Config.Namespace = binding.Namespace
 
-			os.MkdirAll(depDir, os.ModePerm)
-			depManifestPath := filepath.Join(depDir, pa[utils.OW_PROJECT_NAME].(string)+".yaml")
+        pkg, _, err := client.Packages.Get(binding.Name)
+        if err != nil {
+            return err
+        }
 
-			// export the whole project as dependency
-			err := exportProject(pa[utils.OW_PROJECT_NAME].(string), depManifestPath)
-			if err != nil {
-				return err
-			}
-		} else {
-			// showing warning to notify user that exported manifest dependent on unmanaged library which can't be exported
-			fmt.Println("Warning! Dependency package " + binding.Name + " currently unmanaged by any project. Unable to export this package")
-		}
-		client.Config.Namespace = ns
-	}
+        if a := pkg.Annotations.GetValue(utils.MANAGED); a != nil {
+            // decode the JSON blob and retrieve __OW_PROJECT_NAME
+            pa := a.(map[string]interface{})
 
-	return nil
+            os.MkdirAll(depDir, os.ModePerm)
+            depManifestPath := filepath.Join(depDir, pa[utils.OW_PROJECT_NAME].(string)+".yaml")
+
+            // export the whole project as dependency
+            err := exportProject(pa[utils.OW_PROJECT_NAME].(string), depManifestPath)
+            if err != nil {
+                return err
+            }
+        } else {
+            // showing warning to notify user that exported manifest dependent on unmanaged library which can't be exported
+            fmt.Println("Warning! Dependency package " + binding.Name + " currently unmanaged by any project. Unable to export this package")
+        }
+        client.Config.Namespace = ns
+    }
+
+    return nil
 }
 
 func ExportCmdImp(cmd *cobra.Command, args []string) error {
 
-	config, _ = deployers.NewWhiskConfig(wskpropsPath, utils.Flags.DeploymentPath, utils.Flags.ManifestPath)
-	client, _ = deployers.CreateNewClient(config)
+    config, _ = deployers.NewWhiskConfig(wskpropsPath, utils.Flags.DeploymentPath, utils.Flags.ManifestPath)
+    client, _ = deployers.CreateNewClient(config)
 
-	// Init supported runtimes and action files extensions maps
-	setSupportedRuntimes(config.Host)
+    // Init supported runtimes and action files extensions maps
+    setSupportedRuntimes(config.Host)
 
-	return exportProject(utils.Flags.ProjectName, utils.Flags.ManifestPath)
+    return exportProject(utils.Flags.ProjectName, utils.Flags.ManifestPath)
 }
 
 const (
-	JAVA_EXT = ".jar"
-	ZIP_EXT  = ".zip"
-	JAVA     = "java"
+    JAVA_EXT = ".jar"
+    ZIP_EXT  = ".zip"
+    JAVA     = "java"
 )
 
 func getBinaryKindExtension(runtime string) (extension string) {
-	switch strings.ToLower(runtime) {
-	case JAVA:
-		extension = JAVA_EXT
-	default:
-		extension = ZIP_EXT
-	}
+    switch strings.ToLower(runtime) {
+    case JAVA:
+        extension = JAVA_EXT
+    default:
+        extension = ZIP_EXT
+    }
 
-	return extension
+    return extension
 }
 
 func saveCode(action whisk.Action, directory string) (string, error) {
-	var code string
-	var runtime string
-	var exec whisk.Exec
+    var code string
+    var runtime string
+    var exec whisk.Exec
 
-	exec = *action.Exec
-	runtime = strings.Split(exec.Kind, ":")[0]
+    exec = *action.Exec
+    runtime = strings.Split(exec.Kind, ":")[0]
 
-	if exec.Code != nil {
-		code = *exec.Code
-	} else {
-		return "", nil
-	}
+    if exec.Code != nil {
+        code = *exec.Code
+    } else {
+        return "", nil
+    }
 
-	var filename = ""
-	if *exec.Binary {
-		decoded, _ := base64.StdEncoding.DecodeString(code)
-		code = string(decoded)
+    var filename = ""
+    if *exec.Binary {
+        decoded, _ := base64.StdEncoding.DecodeString(code)
+        code = string(decoded)
 
-		filename = action.Name + getBinaryKindExtension(runtime)
-	} else {
-		filename = action.Name + "." + runtimes.FileRuntimeExtensionsMap[action.Exec.Kind]
-	}
+        filename = action.Name + getBinaryKindExtension(runtime)
+    } else {
+        filename = action.Name + "." + runtimes.FileRuntimeExtensionsMap[action.Exec.Kind]
+    }
 
-	os.MkdirAll(directory, os.ModePerm)
+    os.MkdirAll(directory, os.ModePerm)
 
-	path := filepath.Join(directory, filename)
+    path := filepath.Join(directory, filename)
 
-	if err := utils.WriteFile(path, code); err != nil {
-		return "", err
-	}
+    if err := utils.WriteFile(path, code); err != nil {
+        return "", err
+    }
 
-	return filename, nil
+    return filename, nil
 }
 
 func init() {
-	RootCmd.AddCommand(exportCmd)
+    RootCmd.AddCommand(exportCmd)
 }
+

--- a/tests/src/integration/export/export_test.go
+++ b/tests/src/integration/export/export_test.go
@@ -1,5 +1,3 @@
-// +build skip_integration
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -44,6 +42,8 @@ func TestExport(t *testing.T) {
 
 	wskdeploy := common.NewWskdeploy()
 
+    defer os.RemoveAll(targetManifestFolder) 
+
 	_, err := wskdeploy.ManagedDeploymentOnlyManifest(manifestLib1Path)
 	assert.Equal(t, nil, err, "Failed to deploy the lib1 manifest file.")
 
@@ -81,6 +81,8 @@ func SkipTestExportHelloWorld(t *testing.T) {
 	targetManifestFolder := os.Getenv("GOPATH") + EXPORT_TEST_PATH + "tmp-" + strconv.Itoa(rand.Intn(1000)) + "/"
 	targetManifestHelloWorldPath := targetManifestFolder + "manifest-" + projectName + ".yaml"
 
+    defer os.RemoveAll(targetManifestFolder)
+
 	wskdeploy := common.NewWskdeploy()
 
 	_, err := wskdeploy.ManagedDeploymentManifestAndProject(manifestHelloWorldPath, projectName)
@@ -114,6 +116,9 @@ func TestExport2Pack(t *testing.T) {
 	manifest2PackPath := os.Getenv("GOPATH") + EXPORT_TEST_PATH + "manifest_2pack.yaml"
 	targetManifestFolder := os.Getenv("GOPATH") + EXPORT_TEST_PATH + "tmp-" + strconv.Itoa(rand.Intn(1000)) + "/"
 	target2PackManifestPath := targetManifestFolder + "exported2packmanifest.yaml"
+
+    defer os.RemoveAll(targetManifestFolder)
+
 	projectName := "2pack"
 	wskdeploy := common.NewWskdeploy()
 
@@ -135,3 +140,46 @@ func TestExport2Pack(t *testing.T) {
 	_, err = wskdeploy.UndeployManifestPathOnly(manifest2PackPath)
 	assert.Equal(t, nil, err, "Failed to undeploy")
 }
+
+func ExportApi(t *testing.T) {
+	projectName := "ApiExp"
+	wskdeploy := common.NewWskdeploy()
+
+    defer os.RemoveAll(targetManifestFolder)
+
+	_, err := wskdeploy.ManagedDeploymentManifestAndProject(manifestApiExpPath, projectName)
+	assert.Equal(t, nil, err, "Failed to deploy the ApiExp manifest file.")
+
+	_, err = wskdeploy.ExportProject(projectName, targetApiExpManifestPath)
+	assert.Equal(t, nil, err, "Failed to export project.")
+
+	_, err = os.Stat(manifestApiExpPath)
+	assert.Equal(t, nil, err, "Missing exported manifest file")
+
+	_, err = os.Stat(targetManifestFolder + "api-gateway-test/greeting.js")
+	assert.Equal(t, nil, err, "Missing exported api-gateway-test/greeting.js")
+
+	_, err = wskdeploy.UndeployManifestPathOnly(manifestApiExpPath)
+	assert.Equal(t, nil, err, "Failed to undeploy")
+
+	_, err = wskdeploy.ManagedDeploymentOnlyManifest(targetApiExpManifestPath)
+	assert.Equal(t, nil, err, "Failed to redeploy the exported manifest file.")
+
+	_, err = wskdeploy.UndeployManifestPathOnly(targetApiExpManifestPath)
+	assert.Equal(t, nil, err, "Failed to undeploy the exported manifest file")
+}
+
+var (
+	manifestLib1Path = os.Getenv("GOPATH") + "/src/github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/export/manifest_lib1.yaml"
+	manifestLib2Path = os.Getenv("GOPATH") + "/src/github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/export/manifest_lib2.yaml"
+	manifestExtPath  = os.Getenv("GOPATH") + "/src/github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/export/manifest_ext.yaml"
+
+	targetManifestFolder = os.Getenv("GOPATH") + "/src/github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/export/tmp/"
+	targetManifestPath   = targetManifestFolder + "manifest.yaml"
+
+	manifest2PackPath       = os.Getenv("GOPATH") + "/src/github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/export/manifest_2pack.yaml"
+	target2PackManifestPath = targetManifestFolder + "exported2packmanifest.yaml"
+
+	manifestApiExpPath       = os.Getenv("GOPATH") + "/src/github.com/apache/incubator-openwhisk-wskdeploy/tests/src/integration/export/manifest_apiexp.yaml"
+	targetApiExpManifestPath = targetManifestFolder + "exportedapimanifest.yaml"
+)

--- a/tests/src/integration/export/export_test.go
+++ b/tests/src/integration/export/export_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/tests/src/integration/export/export_test.go
+++ b/tests/src/integration/export/export_test.go
@@ -1,3 +1,5 @@
+// +build skip_integration
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/tests/src/integration/export/export_test.go
+++ b/tests/src/integration/export/export_test.go
@@ -143,7 +143,7 @@ func TestExport2Pack(t *testing.T) {
 	assert.Equal(t, nil, err, "Failed to undeploy")
 }
 
-func ExportApi(t *testing.T) {
+func TestExportApi(t *testing.T) {
 	projectName := "ApiExp"
 	wskdeploy := common.NewWskdeploy()
 

--- a/tests/src/integration/export/export_test.go
+++ b/tests/src/integration/export/export_test.go
@@ -1,5 +1,3 @@
-// +build skip_integration
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/tests/src/integration/export/export_test.go
+++ b/tests/src/integration/export/export_test.go
@@ -42,7 +42,7 @@ func TestExport(t *testing.T) {
 
 	wskdeploy := common.NewWskdeploy()
 
-    defer os.RemoveAll(targetManifestFolder) 
+	defer os.RemoveAll(targetManifestFolder)
 
 	_, err := wskdeploy.ManagedDeploymentOnlyManifest(manifestLib1Path)
 	assert.Equal(t, nil, err, "Failed to deploy the lib1 manifest file.")
@@ -81,7 +81,7 @@ func SkipTestExportHelloWorld(t *testing.T) {
 	targetManifestFolder := os.Getenv("GOPATH") + EXPORT_TEST_PATH + "tmp-" + strconv.Itoa(rand.Intn(1000)) + "/"
 	targetManifestHelloWorldPath := targetManifestFolder + "manifest-" + projectName + ".yaml"
 
-    defer os.RemoveAll(targetManifestFolder)
+	defer os.RemoveAll(targetManifestFolder)
 
 	wskdeploy := common.NewWskdeploy()
 
@@ -117,7 +117,7 @@ func TestExport2Pack(t *testing.T) {
 	targetManifestFolder := os.Getenv("GOPATH") + EXPORT_TEST_PATH + "tmp-" + strconv.Itoa(rand.Intn(1000)) + "/"
 	target2PackManifestPath := targetManifestFolder + "exported2packmanifest.yaml"
 
-    defer os.RemoveAll(targetManifestFolder)
+	defer os.RemoveAll(targetManifestFolder)
 
 	projectName := "2pack"
 	wskdeploy := common.NewWskdeploy()
@@ -145,7 +145,7 @@ func ExportApi(t *testing.T) {
 	projectName := "ApiExp"
 	wskdeploy := common.NewWskdeploy()
 
-    defer os.RemoveAll(targetManifestFolder)
+	defer os.RemoveAll(targetManifestFolder)
 
 	_, err := wskdeploy.ManagedDeploymentManifestAndProject(manifestApiExpPath, projectName)
 	assert.Equal(t, nil, err, "Failed to deploy the ApiExp manifest file.")

--- a/tests/src/integration/export/manifest_apiexp.yaml
+++ b/tests/src/integration/export/manifest_apiexp.yaml
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements; and to You under the Apache License, Version 2.0.
+
+packages:
+    api-gateway-test:
+        version: 1.0
+        license: Apache-2.0
+        actions:
+            greeting:
+                web-export: true
+                version: 1.0
+                function: src/greeting.js
+                runtime: nodejs:6
+        # new top-level key for defining groups of named APIs
+        apis:
+            hello-world:
+                hello:
+                    world:
+                        greeting:
+                            method: GET
+                            response: http


### PR DESCRIPTION
Exporting APIs when its target action is managed by specified project.

Currently Openwhisk missing support for annotations in APIs entities. 
In order to support APIs export:

(1) _export packages_
(2) _export actions_
.
.
.
(n) **_export APIs_**
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;get all APIs
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;for API in APIs
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if API target action in exported packages (1)
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;add API to exported manifest