### PR TITLE
Add `go get` to populate the vendor file

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Once your environment is setup, download `wskdeploy` and its dependencies:
 ```sh
 $ cd $GOPATH
 $ go get github.com/apache/incubator-openwhisk-wskdeploy  # see known issues below if you get an error
+$ go get github.com/tools/godep # get the dependency manager
 ```
 
 ### Build the binary
@@ -64,7 +65,7 @@ $ go get github.com/apache/incubator-openwhisk-wskdeploy  # see known issues bel
 Use the Go utility to build the ```wskdeploy``` binary as follows:
 ```sh
 $ cd src/github.com/apache/incubator-openwhisk-wskdeploy/
-$ go get
+$ godep restore
 $ go build -o wskdeploy
 ```
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ $ go get github.com/apache/incubator-openwhisk-wskdeploy  # see known issues bel
 Use the Go utility to build the ```wskdeploy``` binary as follows:
 ```sh
 $ cd src/github.com/apache/incubator-openwhisk-wskdeploy/
+$ go get
 $ go build -o wskdeploy
 ```
 


### PR DESCRIPTION
I have very limited Go knowledge and kept bumping into errors when compiling `wskdeploy`. I learned that Go needs a way to pull in it's dependencies. So I added that to the documentation below to make it easier for people following in my footsteps.