### PR TITLE
Enable export verbose output

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -116,6 +116,10 @@ func ExportAction(actionName string, packageName string, maniyaml *parsers.YAML,
 }
 
 func exportProject(projectName string, targetManifest string) error {
+
+        whisk.SetVerbose(utils.Flags.Verbose)
+        whisk.SetDebug(utils.Flags.Trace)
+
 	maniyaml := &parsers.YAML{}
 	maniyaml.Project.Name = projectName
 

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -117,8 +117,8 @@ func ExportAction(actionName string, packageName string, maniyaml *parsers.YAML,
 
 func exportProject(projectName string, targetManifest string) error {
 
-        whisk.SetVerbose(utils.Flags.Verbose)
-        whisk.SetDebug(utils.Flags.Trace)
+	whisk.SetVerbose(utils.Flags.Verbose)
+	whisk.SetDebug(utils.Flags.Trace)
 
 	maniyaml := &parsers.YAML{}
 	maniyaml.Project.Name = projectName


### PR DESCRIPTION
When using "project export", similar to project deployment, verbose stdout should be supported