### PR TITLE
Quickfix: Add fallback method to find wskprops when go-client fails

### DIFF
--- a/utils/misc.go
+++ b/utils/misc.go
@@ -60,10 +60,19 @@ type RuleRecord struct {
 	Packagename string
 }
 
+func fallbackHome() string {
+	if home := os.Getenv("HOME"); home != "" {
+		return home
+	}
+	// For Windows.
+	return os.Getenv("UserProfile")
+}
+
 func GetHomeDirectory() string {
 	usr, err := user.Current()
 	if err != nil {
-		return ""
+
+		return fallbackHome()
 	}
 
 	return usr.HomeDir


### PR DESCRIPTION
We need a longer-term fix that starts in the Go Client (which we use in some cases) where Go client needs to be made more robust and perhaps look to packages such  [ (i.e., https://github.com/mitchellh/go-homedir) it appears to be a single file under MIT license which if we switch to we would need to note.](https://github.com/mitchellh/go-homedir).

Which is used by the CLI and appears to be a single file under MIT license which if we switch to we would need to note.  This means go-client, and CLI may need to be cleaned up and once that is done wskdeploy would strictly rely upon go-client ReadProp() impl.