### PR TITLE
Add PHP 7.3 runtime

### DIFF
--- a/runtimes/runtimes.go
+++ b/runtimes/runtimes.go
@@ -484,6 +484,20 @@ var RUNTIME_DETAILS = []byte(`{
                     "attachmentName": "codefile",
                     "attachmentType": "text/plain"
                 }
+            },
+            {
+                "kind": "php:7.3",
+                "default": true,
+                "deprecated": false,
+                "image": {
+                    "prefix": "openwhisk",
+                    "name": "action-php-v7.3",
+                    "tag": "latest"
+                },
+                "attached": {
+                    "attachmentName": "codefile",
+                    "attachmentType": "text/plain"
+                }
             }
         ],
         "ruby": [

--- a/runtimes/runtimes.go
+++ b/runtimes/runtimes.go
@@ -473,7 +473,7 @@ var RUNTIME_DETAILS = []byte(`{
             },
             {
                 "kind": "php:7.2",
-                "default": true,
+                "default": false,
                 "deprecated": false,
                 "image": {
                     "prefix": "openwhisk",

--- a/specification/html/spec_actions.md
+++ b/specification/html/spec_actions.md
@@ -138,6 +138,7 @@ These packages may vary by OpenWhisk release; examples of supported runtimes as 
 | nodejs@8 | nodejs:8 | openwhisk/action-nodejs-v8:latest | Latest NodeJS 8 runtime |
 | nodejs@6 | nodejs:6 | openwhisk/nodejs6action:latest | Latest NodeJS 6 runtime |
 | java | java | openwhisk/java8action:latest | Latest Java (8) language runtime |
+| php, php@7.3 | php:7.3 | openwhisk/action-php-v7.3:latest | Latest PHP (7.3) language runtime |
 | php, php@7.2 | php:7.2 | openwhisk/action-php-v7.2:latest | Latest PHP (7.2) language runtime |
 | php, php@7.1 | php:7.1 | openwhisk/action-php-v7.1:latest | Latest PHP (7.1) language runtime |
 | python@3 | python:3 | openwhisk/python3action:latest | Latest Python 3 language runtime |

--- a/tests/src/integration/runtimetests/manifest.yaml
+++ b/tests/src/integration/runtimetests/manifest.yaml
@@ -36,11 +36,31 @@ packages:
                     place: string
                 outputs:
                     payload: string
-            greetingphp-with-explicit-runtime:
+            greetingphp71-with-explicit-runtime:
                 web-export: true
                 version: 1.0
                 function: src/hello.php
                 runtime: php:7.1
+                inputs:
+                    name: string
+                    place: string
+                outputs:
+                    payload: string
+            greetingphp72-with-explicit-runtime:
+                web-export: true
+                version: 1.0
+                function: src/hello.php
+                runtime: php:7.2
+                inputs:
+                    name: string
+                    place: string
+                outputs:
+                    payload: string
+            greetingphp73-with-explicit-runtime:
+                web-export: true
+                version: 1.0
+                function: src/hello.php
+                runtime: php:7.3
                 inputs:
                     name: string
                     place: string


### PR DESCRIPTION
Add support for the new PHP 7.3 runtime as per https://github.com/apache/incubator-openwhisk/issues/4174