### PR TITLE
fix test syntax errors

### DIFF
--- a/deployers/deploymentreader_test.go
+++ b/deployers/deploymentreader_test.go
@@ -137,12 +137,12 @@ func TestDeploymentReader_ProjectBindTrigger(t *testing.T) {
 	// test Project exists with expected name in Deployment file
 	projectNameDeploy := dReader.DeploymentDescriptor.GetProject().Name
 	if projectNameDeploy != TEST_PROJECT {
-		assert.Fail(t, fmt.Sprintf(TEST_ERROR_DEPLOYMENT_FIND_PROJECT, TEST_PROJECT))
+		assert.Fail(t, fmt.Sprintf(TEST_ERROR_DEPLOYMENT_FIND_PROJECT, projectNameDeploy, TEST_PROJECT))
 	}
 
 	// test that the Project has Packages
 	if len(dReader.DeploymentDescriptor.GetProject().Packages) == 0 {
-		assert.Fail(t, fmt.Sprintf(TEST_ERROR_DEPLOYMENT_FIND_PACKAGES, TEST_PROJECT))
+		assert.Fail(t, fmt.Sprintf(TEST_ERROR_DEPLOYMENT_FIND_PACKAGES, projectNameDeploy, TEST_PROJECT))
 	}
 
 	trigger := sDeployer.Deployment.Triggers[TEST_TRIGGER]

--- a/deployers/manifestreader_test.go
+++ b/deployers/manifestreader_test.go
@@ -98,7 +98,7 @@ func TestManifestReader_InitPackages(t *testing.T) {
 
 	err = manifestReader.InitPackages(manifestParser, manifest, whisk.KeyValue{})
 	assert.Nil(t, err, fmt.Sprintf(TEST_ERROR_MANIFEST_SET_PACKAGES, manifestFile))
-	assert.Equal(t, 3, len(deployer.Deployment.Packages), fmt.Sprintf(TEST_ERROR_MANIFEST_SET_PACKAGES, manifestFile, ""))
+	assert.Equal(t, 3, len(deployer.Deployment.Packages), fmt.Sprintf(TEST_ERROR_MANIFEST_SET_PACKAGES, manifestFile))
 
 	expectedParametersAndAnnotations := 0
 

--- a/parsers/manifest_parser_test.go
+++ b/parsers/manifest_parser_test.go
@@ -45,8 +45,8 @@ const (
 	TEST_MSG_ACTION_FUNCTION_PATH_MISMATCH          = "Action function path mismatched."
 	TEST_MSG_ACTION_FUNCTION_RUNTIME_MISMATCH       = "Action function runtime mismatched."
 	TEST_MSG_ACTION_FUNCTION_MAIN_MISMATCH          = "Action function main name mismatch."
-	TEST_MSG_ACTION_PARAMETER_TYPE_MISMATCH         = "Action parameter [%s] had a type mismatch."
-	TEST_MSG_ACTION_PARAMETER_VALUE_MISMATCH        = "Action parameter [%s] had a value mismatch."
+	TEST_MSG_ACTION_PARAMETER_TYPE_MISMATCH         = "Action parameter [%v] had a type mismatch."
+	TEST_MSG_ACTION_PARAMETER_VALUE_MISMATCH        = "Action parameter [%v] had a value mismatch."
 	TEST_MSG_PARAMETER_NUMBER_MISMATCH              = "Number of Paramaters mismatched."
 	TEST_MSG_MANIFEST_UNMARSHALL_ERROR_EXPECTED     = "Manifest [%s]: Expected Unmarshal error."
 	TEST_MSG_ACTION_FUNCTION_RUNTIME_ERROR_EXPECTED = "Manifest [%s]: Expected runtime error."
@@ -580,7 +580,7 @@ func TestComposeActionsForValidRuntime_ZipAction(t *testing.T) {
 	assert.Nil(t, err, fmt.Sprintf(TEST_ERROR_COMPOSE_ACTION_FAILURE, tmpfile))
 	for _, action := range actions {
 		if action.Action.Name == "hello" {
-			assert.Equal(t, action.Action.Exec.Kind, "nodejs:6", fmt.Sprintf(TEST_MSG_ACTION_FUNCTION_RUNTIME_MISMATCH, action))
+			assert.Equal(t, action.Action.Exec.Kind, "nodejs:6", fmt.Sprintf(TEST_MSG_ACTION_FUNCTION_RUNTIME_MISMATCH))
 		}
 
 	}

--- a/runtimes/runtimes_test.go
+++ b/runtimes/runtimes_test.go
@@ -33,11 +33,11 @@ func TestParseOpenWhisk(t *testing.T) {
 	println(converted["python"])
 	//println(converted["go"])
 	assert.Equal(t, 3, len(converted["nodejs"]), "not expected length")
-	assert.Equal(t, 2, len(converted["php"]), "not expected length")
+	assert.Equal(t, 3, len(converted["php"]), "not expected length")
 	assert.Equal(t, 1, len(converted["java"]), "not expected length")
 	assert.Equal(t, 6, len(converted["python"]), "not expected length")
 	assert.Equal(t, 1, len(converted["ruby"]), "not expected length")
-	assert.Equal(t, 2, len(converted["swift"]), "not expected length")
+	assert.Equal(t, 3, len(converted["swift"]), "not expected length")
 	// cannot pass this test until it is deployed in OpenWhisk
 	//assert.Equal(t, 2, len(converted["go"]), "not expected length")
 }


### PR DESCRIPTION
go 1.11 will fail on these tests due to incorrect syntax, so fixing them now