### PR TITLE
raise memorySize limit to 2048MB

### DIFF
--- a/utils/validation.go
+++ b/utils/validation.go
@@ -153,7 +153,7 @@ func LimitsMemoryValidation(memory *int) bool {
 	if memory == nil {
 		return true
 	}
-	if *memory < 128 || *memory > 512 {
+	if *memory < 128 || *memory > 2048 {
 		wskprint.PrintlnOpenWhiskWarning(wski18n.T(wski18n.ID_WARN_LIMITS_MEMORY_SIZE))
 		return false
 	}


### PR DESCRIPTION
memorySize is limited to 512MB in wskdeploy, but not in OpenWhisk
#1033 