### PR TITLE
update runtimes used in tests

### DIFF
--- a/tests/src/integration/helloworld/manifest.yaml
+++ b/tests/src/integration/helloworld/manifest.yaml
@@ -109,7 +109,7 @@ packages:
         # helloworld action in swift
         helloSwift:
           function: actions/hello.swift
-          runtime: swift:3.1.1
+          runtime: swift:4.2
           inputs:
             name:
               type: string
@@ -130,7 +130,7 @@ packages:
                     print (msg)
                     return msg
                 }
-          runtime: swift:3.1.1
+          runtime: swift:4.2
           inputs:
             name:
               type: string

--- a/tests/src/integration/runtimetests/manifest.yaml
+++ b/tests/src/integration/runtimetests/manifest.yaml
@@ -106,26 +106,6 @@ packages:
                     place: string
                 outputs:
                     payload: string
-            greetingswift311-with-explicit-runtime:
-                web-export: true
-                version: 1.0
-                function: src/hello.swift
-                runtime: swift:3.1.1
-                inputs:
-                    name: string
-                    place: string
-                outputs:
-                    payload: string
-            greetingswift41-with-explicit-runtime:
-                web-export: true
-                version: 1.0
-                function: src/hello.swift
-                runtime: swift:4.1
-                inputs:
-                    name: string
-                    place: string
-                outputs:
-                    payload: string
             greetingswift42-with-explicit-runtime:
                 web-export: true
                 version: 1.0
@@ -307,7 +287,7 @@ packages:
             helloworldjava-with-swift-explicit-runtime:
                 function: src/hello.jar
                 main: Hello
-                runtime: swift:3.1.1
+                runtime: swift:4.2
             helloworldjava-with-random-explicit-runtime:
                 function: src/hello.jar
                 main: Hello
@@ -315,4 +295,4 @@ packages:
             helloworlddotnet22-with-swift-explicit-runtime:
                 function: src/helloDotNet.zip
                 main: Apache.OpenWhisk.Example.Dotnet::Apache.OpenWhisk.Example.Dotnet.Hello::Main
-                runtime: swift:3.1.1
+                runtime: swift:4.2


### PR DESCRIPTION
Tests now fail with invalid runtimes: https://travis-ci.org/apache/incubator-openwhisk-wskdeploy/builds/494723361

This is related to changes in incubator-openwhisk, that removed some old runtimes: [apache/incubator-openwhisk#4254](https://github.com/apache/incubator-openwhisk/pull/4254)

See #1035 

This updates said runtimes in the tests