### PR TITLE
Added date and commit SHA to the version command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ before_deploy:
       export GIT_TAG=$TRAVIS_TAG;
       export TAG=true;
   fi
-- ./gradlew --console=plain releaseBinaries -PpackageVersion=$GIT_TAG
+- ./gradlew --console=plain releaseBinaries -PpackageVersion=$GIT_TAG -PgitCommit=$(git rev-parse HEAD) -PbuildDate=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 - "./tools/travis/build_tag_releases.sh $build_file_name $GIT_TAG"
 - export RELEASE_PKG_FILE="$(cd "$TRAVIS_BUILD_DIR/release" && ls ${zip_file_name}-*.tgz ${zip_file_name}-*.zip)"
 - echo "Deploying $RELEASE_PKG_FILE to GitHub releases."

--- a/Makefile
+++ b/Makefile
@@ -24,11 +24,13 @@ VERSION=latest
 
 BUILD=`git rev-parse HEAD`
 
+BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"`
+
 deps:
 	@echo "Installing dependencies"
 	godep restore -v
 
-LDFLAGS=-ldflags "-X main.Version=${VERSION} -X main.Build=`git rev-parse HEAD` "
+LDFLAGS=-ldflags "-X main.Version=${VERSION} -X main.GitCommit=${BUILD} -X main.BuildDate=${BUILD_DATE} -X main.Build=`git rev-parse HEAD` "
 
 test: deps
 	@echo "Testing"

--- a/build.gradle
+++ b/build.gradle
@@ -185,6 +185,12 @@ OpenWhiskPlatform.zipFileName =
 project.ext.packageVersion =
         rootProject.findProperty('packageVersion') ?: 'latest'
 
+project.ext.gitCommit =
+        rootProject.findProperty('gitCommit') ?: 'unset'
+
+project.ext.buildDate =
+        rootProject.findProperty('buildDate') ?: 'unset'
+
 String buildFileName = System.env['build_file_name'] ?:
         (rootProject.findProperty('buildFileName') ?: 'wskdeploy')
 
@@ -237,7 +243,7 @@ goBuild {
     // WARNING:  The single quotes are intentional!  The gogradle plugin will
     //           parse the command with the GString engine at execution time.
     go(['build',
-        '-ldflags', "-X main.Version=${packageVersion}" as String,
+        '-ldflags', "-X main.Version=${packageVersion} -X main.GitCommit=${gitCommit} -X main.BuildDate=${buildDate}" as String,
         '-o', './build/${GOOS}-${GOARCH}/'+buildFileName+'${GOEXE}',
         golang.packagePath ] as List<String>)
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -38,5 +38,9 @@ var versionCmd = &cobra.Command{
 			// Note: no need to translate the following string
 			// TODO(#767) - Flags.CliVersion are not set during build
 			fmt.Sprintf("wskdeploy version: %s", utils.Flags.CliVersion))
+		wskprint.PrintlnOpenWhiskOutput(
+			fmt.Sprintf("wskdeploy git commit: %s", utils.Flags.CliGitCommit))
+		wskprint.PrintlnOpenWhiskOutput(
+			fmt.Sprintf("wskdeploy build date: %s", utils.Flags.CliBuildDate))
 	},
 }

--- a/main.go
+++ b/main.go
@@ -28,9 +28,13 @@ func main() {
 
 var (
 	//Version ...The Version of the tool
-	Version = "unset"
+	Version   = "unset"
+	GitCommit = "unset"
+	BuildDate = "unset"
 )
 
 func init() {
 	utils.Flags.CliVersion = Version
+	utils.Flags.CliGitCommit = GitCommit
+	utils.Flags.CliBuildDate = BuildDate
 }

--- a/tools/travis/build_tag_releases.sh
+++ b/tools/travis/build_tag_releases.sh
@@ -20,6 +20,8 @@ declare -a os_list=("linux" "darwin" "windows")
 declare -a arc_list=("amd64" "386")
 build_file_name=${1:-"wskdeploy"}
 build_version=${2:-"$TRAVIS_TAG"}
+gitCommit=$(git rev-parse HEAD)
+buildDate=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 for os in "${os_list[@]}"
 do
@@ -34,7 +36,7 @@ do
             os_name="mac"
         fi
         cd $TRAVIS_BUILD_DIR
-        GOOS=$os GOARCH=$arc go build -ldflags "-X main.Version=$build_version" -o build/$os/$wskdeploy
+        GOOS=$os GOARCH=$arc go build -ldflags "-X main.Version=$build_version -X main.GitCommit=$gitCommit -X main.BuildDate=$buildDate" -o build/$os/$wskdeploy
         cd build/$os
         if [[ "$os" == "linux" ]]; then
             tar -czvf "$TRAVIS_BUILD_DIR/$build_file_name-$TRAVIS_TAG-$os_name-$arc.tgz" $wskdeploy

--- a/utils/flags.go
+++ b/utils/flags.go
@@ -29,6 +29,8 @@ type WskDeployFlags struct {
 	ApiVersion       string // OpenWhisk version
 	CfgFile          string
 	CliVersion       string
+	CliGitCommit     string
+	CliBuildDate     string
 	ProjectPath      string
 	DeploymentPath   string
 	ManifestPath     string


### PR DESCRIPTION
This commit adds in a date and the head commit SHA. This makes it easy
for end-users to verify if their binary is indeed the latest one. The
date and git commit are also added in builds for release candidates.

Example:
```
./wskdeploy version
wskdeploy version: latest
wskdeploy git commit: 50aacbc7992720290f8a4a8696d2288d3c52a0e7
wskdeploy build date: 2019-03-28T20:41:05Z
```

Fixes: #1000 

Signed-off-by: AnthonyAmanse <ghieamanse@gmail.com>